### PR TITLE
Issue 38143: Parent Experiments value lost if description is updated

### DIFF
--- a/OConnorExperiments/resources/web/ocexp/internal/Experiment.js
+++ b/OConnorExperiments/resources/web/ocexp/internal/Experiment.js
@@ -201,6 +201,10 @@ LABKEY.ocexp.internal.Experiment = new function () {
         for (var i = 0; i < a.length; i++)
         {
             var item = a[i];
+            // Issue 38143: be sure value is a string, not a numeric primitive
+            if (!Ext4.isString(item)) {
+                item = item.toString();
+            }
             if (item.length > 0)
                 o[item] = true;
         }


### PR DESCRIPTION
Backport of change that was already merged to develop

Did we decide that we don't need triage review for single-distribution module changes like this one?