### PR TITLE
Remove <labkey:scriptDependency/> usage

### DIFF
--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/view/history.jsp
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/view/history.jsp
@@ -37,15 +37,6 @@
     User user = getUser();
     Container c = getContainer();
 %>
-<%!
-    @Override
-    public void addClientDependencies(ClientDependencies dependencies)
-    {
-        dependencies.add("clientapi");
-    }
-%>
-<labkey:scriptDependency/>
-
 <h3>Experiment History</h3>
 <%
     {


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/970

#### Changes
* Remove usage of `<labkey:scriptDependency/>` as this page does not make use of any custom scripts.
* Remove unnecessary explicit request for "clientapi" lib as this library is guaranteed to be available on every page.