### PR TITLE
Fb jsp final

### DIFF
--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/view/migrateData.jsp
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/view/migrateData.jsp
@@ -16,9 +16,7 @@
  */
 %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<%@ page import="org.labkey.api.view.HttpView"%>
-<%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.oconnorexperiments.OConnorExperimentsController" %>
+<%@ page import="org.labkey.oconnorexperiments.OConnorExperimentsController"%>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <form <%=formAction(OConnorExperimentsController.MigrateDataAction.class, Method.Post)%>><labkey:csrf/>

--- a/genotyping/src/org/labkey/genotyping/view/analyze.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/analyze.jsp
@@ -133,7 +133,7 @@ var f = new LABKEY.ext.FormPanel({
         description,
         selectedSamples
     ],
-    buttons:[{text:'Submit', type:'submit', handler:submit}, {text:'Cancel', handler:function() {document.location = <%=q(bean.getReturnURL().toString())%>;}}],
+    buttons:[{text:'Submit', type:'submit', handler:submit}, {text:'Cancel', handler:function() {document.location = <%=q(bean.getReturnURL())%>;}}],
     buttonAlign:'left'
 });
 

--- a/genotyping/src/org/labkey/genotyping/view/configure.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/configure.jsp
@@ -154,13 +154,13 @@
         </tr>
         <tr><td>&nbsp;</td></tr>
         <tr>
-            <td><a href="<%=h(animalQueryURL.getLocalURIString())%>">Animal</a></td>
+            <td><a href="<%=h(animalQueryURL)%>">Animal</a></td>
             <td>
                 <%=link("configure", animalEditDomainURL).id("configureAnimal")%>
             </td>
         </tr>
         <tr>
-            <td><a href="<%=h(haplotypeQueryURL.getLocalURIString())%>">Haplotype</a></td>
+            <td><a href="<%=h(haplotypeQueryURL)%>">Haplotype</a></td>
             <td>
                 <%=link("configure", haplotypeEditDomainURL).id("configureHaplotype")%>
             </td>

--- a/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
@@ -111,7 +111,7 @@
                             commands: commands,
                             success: function(data) {
                                 assignmentForm.getEl().unmask();
-                                window.location = <%=q(returnURL.toString())%>
+                                window.location = <%=q(returnURL)%>
                             },
                             failure: function(response) {
                                 alert(response.exception);
@@ -123,7 +123,7 @@
                 {
                     text: 'Cancel',
                     handler: function(){
-                        window.location = <%=q(returnURL.toString())%>
+                        window.location = <%=q(returnURL)%>
                     }
                 }
             ],

--- a/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
@@ -143,7 +143,7 @@
                 {
                     text: 'Cancel',
                     handler: function(){
-                        window.location = <%=q(bean.getReturnURL().toString())%>;
+                        window.location = <%=q(bean.getReturnURL())%>;
                     }
                 }
             ],

--- a/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
@@ -37,9 +37,7 @@
 
     final String copyPasteDivId = "copypasteDiv" + getRequestScopedUID();
 %>
-<labkey:form action="importHaplotypeAssignments.post" method="post">
-    <div id="<%=h(copyPasteDivId)%>"></div>
-</labkey:form>
+<div id="<%=h(copyPasteDivId)%>"></div>
 
 <script type="text/javascript">
     var expectedHeaders = [];

--- a/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
@@ -17,12 +17,12 @@
 %>
 
 <%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.genotyping.HaplotypeDataCollector" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.genotyping.HaplotypeAssayProvider" %>
-<%@ page import="java.util.Map" %>
 <%@ page import="org.labkey.genotyping.HaplotypeColumnMappingProperty" %>
+<%@ page import="org.labkey.genotyping.HaplotypeDataCollector" %>
 <%@ page import="org.labkey.genotyping.HaplotypeProtocolBean" %>
+<%@ page import="java.util.Map" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%

--- a/genotyping/src/org/labkey/genotyping/view/mySettings.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/mySettings.jsp
@@ -17,6 +17,7 @@
 %>
 <%@ page import="org.labkey.api.util.URLHelper"%>
 <%@ page import="org.labkey.genotyping.GenotypingController" %>
+<%@ page import="org.labkey.genotyping.GenotypingController.MySettingsAction" %>
 <%@ page import="org.labkey.genotyping.galaxy.GalaxyFolderSettings" %>
 <%@ page import="org.labkey.genotyping.galaxy.GalaxyManager" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -34,7 +35,7 @@
         preferencesHTML = "<a href=\"" + h(userURL.getURIString()) + "\" target=\"pref\">" + preferencesHTML + "</a>";
     }
 %>
-<labkey:form action="mySettings.post" method="post">
+<labkey:form action="<%=urlFor(MySettingsAction.class)%>" method="post">
     <table>
         <%=formatMissedErrorsInTable("form", 2)%>
         <tr>


### PR DESCRIPTION
#### Rationale
Use `q(URLHelper)` and `h(URLHelper)`. Use `urlFor()` instead of hard-coded strings. Remove unnecessary (and misleading) form

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549
