### PR TITLE
Rename JspBase.getPermissiveJspWriter(out) to getUnsafeJspWriter(out) for consistency

### DIFF
--- a/genotyping/src/org/labkey/genotyping/view/mhcQuery.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/mhcQuery.jsp
@@ -21,7 +21,7 @@
 <%@ page extends="org.labkey.api.jsp.JspContext" %>
 <%
     // Turn off warnings/exceptions for unencoded Strings in this JSP since it's not generating HTML
-    out = getPermissiveJspWriter(out);
+    out = getUnsafeJspWriter(out);
 
     ImportAnalysisJob.QueryContext ctx = (ImportAnalysisJob.QueryContext)getModelBean();
     SqlDialect dialect = ctx.schema.getSqlDialect();


### PR DESCRIPTION
#### Rationale
Rename `JspBase.getPermissiveJspWriter(out)` to `getUnsafeJspWriter(out)` for consistency with other `unsafe*()` methods

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1560