### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/genotyping/build.gradle
+++ b/genotyping/build.gradle
@@ -7,4 +7,7 @@ dependencies
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "list"), depProjectConfig: 'published', depExtension: 'module')
 }

--- a/genotyping/module.properties
+++ b/genotyping/module.properties
@@ -1,2 +1,1 @@
 ModuleClass: org.labkey.genotyping.GenotypingModule
-ModuleDependencies: Experiment, List


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Add missing module dependencies
* Move module dependency declarations from `module.properties` files to `build.gradle` files