### PR TITLE
Add build.gradle file in anticipation of removal of modules/build.gradle

### DIFF
--- a/OConnor/build.gradle
+++ b/OConnor/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}

--- a/OConnorExperiments/build.gradle
+++ b/OConnorExperiments/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.module'
+}

--- a/OConnorRepository/build.gradle
+++ b/OConnorRepository/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}

--- a/genotyping/build.gradle
+++ b/genotyping/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies 
 {
    external "com.github.samtools:htsjdk:${htsjdkVersion}"


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file
