### PR TITLE
Issue 42355: Perf problem during copy-to-study with many rows

### DIFF
--- a/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
@@ -56,6 +56,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -125,12 +126,6 @@ public class HaplotypeAssayProvider extends AbstractAssayProvider
                 return FieldKey.fromParts("RunId", "Created");
             }
         };
-    }
-
-    @Override
-    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
-    {
-        return null;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Users want to be able to copy large assay runs to study datasets. It's painfully slow because we are iterating on each row and doing lots of DB queries

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1945

#### Changes
* Switch AssayProvider to encourage implementations to query rows in bulk
* Cache ExpData, ExpRun, and ExpExperiment references during process as they're likely to be shared by result rows