### PR TITLE
Update expected error message

### DIFF
--- a/genotyping/test/src/org/labkey/test/tests/GenotypingTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/GenotypingTest.java
@@ -90,7 +90,7 @@ public class GenotypingTest extends GenotypingBaseTest
         }
         catch (NoSuchElementException expected)
         {
-            if (!expected.getMessage().startsWith("Cannot locate element with text: " + first454importNum))
+            if (!expected.getMessage().startsWith("Cannot locate option with text: " + first454importNum))
                 throw expected;
         }
     }


### PR DESCRIPTION
#### Rationale
The `NoSuchElementException` message has changed in Selenium 4

#### Changes
* Update expected error message when attempting an invalid re-import
