### PR TITLE
Clean up study.xml files in referenceStudies

### DIFF
--- a/OConnorRepository/tools/study/study.xml
+++ b/OConnorRepository/tools/study/study.xml
@@ -12,11 +12,4 @@
     <definition file="RepositoryStudy.dataset"/>
   </datasets>
 
-  <missingValueIndicators>
-      <missingValueIndicator indicator="E" label="Value is estimated."/>
-      <missingValueIndicator indicator="Q" label="Data currently under quality control review."/>
-      <missingValueIndicator indicator="A" label="Data value is abnormal."/>
-      <missingValueIndicator indicator="N" label="Required field marked by site as 'data not available'."/>
-  </missingValueIndicators>
-
 </study>


### PR DESCRIPTION
#### Rationale
`<missingValueIndicators>` element is no longer supported in `study.xml`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2925