### PR TITLE
Remove unused <categories> elements from datasets_manifest.xml files in sample archives

### DIFF
--- a/OConnorRepository/tools/study/study/datasets/datasets_manifest.xml
+++ b/OConnorRepository/tools/study/study/datasets/datasets_manifest.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-  <categories>
-    <category>Demographics</category>
-  </categories>
   <datasets>
     <dataset name="Demographics" id="1012" category="Demographics" demographicData="true"/>
     <dataset name="ViralChallenges" id="1013" />


### PR DESCRIPTION
#### Rationale
Support for unused `<categories>` element has been removed

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062