### PR TITLE
Issue 45020: Genotyping SampleManager failing to resolve primary key column upon import

### DIFF
--- a/genotyping/src/org/labkey/genotyping/SampleManager.java
+++ b/genotyping/src/org/labkey/genotyping/SampleManager.java
@@ -97,7 +97,7 @@ public class SampleManager
         ColumnInfo keyColumn = qHelper.getTableInfo().getColumn("Key");
         if (null == keyColumn)
             throw new IllegalStateException("SampleManager: Expected Key column to be able to get sample.");
-        FieldKey fieldKey = FieldKey.fromString(keyColumn.getAlias());
+        FieldKey fieldKey = FieldKey.fromString(keyColumn.getName());
 
         try (Results results = qHelper.select(qHelper.getTableInfo().getDefaultVisibleColumns(), null))
         {


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45020](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45020) where Genotyping SampleManager is failing to resolve primary key column upon import.

CI results: https://teamcity.labkey.org/buildConfiguration/LabKey_223Release_Community_DailySuites_CustomModulesSqlserver/1735812?buildTab=tests

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3015

#### Changes
* Resolve keyColumn by name rather than alias. Aliases can get remapped causing these lookups into a result set to not match.