### PR TITLE
Update test to account for FieldDefinition changes

### DIFF
--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -25,7 +25,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.OConnor;
 import org.labkey.test.components.DomainDesignerPage;
-import org.labkey.test.components.domain.AdvancedFieldSetting;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
@@ -39,7 +38,6 @@ import org.openqa.selenium.interactions.Actions;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -233,17 +231,15 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
 
             for (String[] haplotype : extraHaplotypes)
             {
-                domainFormPanel.addField(haplotype[0] + "1")
+                domainFormPanel.addField(new FieldDefinition(haplotype[0] + "1")
                         .setLabel(haplotype[1] + " 1")
-                        .setAdvancedSettings(Map.of(
-                                AdvancedFieldSetting.shownInInsertView, false,
-                                AdvancedFieldSetting.shownInUpdateView, false));
+                        .setShownInInsertView(false)
+                        .setShownInUpdateView(false));
 
-                domainFormPanel.addField(haplotype[0] + "2")
+                domainFormPanel.addField(new FieldDefinition(haplotype[0] + "2")
                         .setLabel(haplotype[1] + " 2")
-                        .setAdvancedSettings(Map.of(
-                                AdvancedFieldSetting.shownInInsertView, false,
-                                AdvancedFieldSetting.shownInUpdateView, false));
+                        .setShownInInsertView(false)
+                        .setShownInUpdateView(false));
             }
         }
 


### PR DESCRIPTION
#### Rationale
`AdvancedFieldSetting` has been refactored. Just set options via `FieldDefinition` instead.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1414

#### Changes
* Use `FieldDefinition` to configure assay fields
