### PR TITLE
Ticket 48504: Very slow AggregatedAnalysisResults query

### DIFF
--- a/genotyping/resources/assay/Haplotype/queries/AggregatedAnalysisResults.sql
+++ b/genotyping/resources/assay/Haplotype/queries/AggregatedAnalysisResults.sql
@@ -16,57 +16,56 @@
 -- query to display analysis results with one animal per row
 -- NOTE: this query could probably use some optimization at some point.
 SELECT
-  Summary.AnimalId,
-  Summary.TotalReads,
-  Summary.TotalIdentifiedReads,
-  Summary.TotalPercentUnknown,
-  a.ConcatenatedHaplotypes,
-  CASE WHEN ac.AssignmentCount > 2 THEN TRUE ELSE FALSE END AS InconsistentAssignments,
-  ac.AssignmentCount,
-  -- We don't know the names of all of the haplotype types (A, B, DR, STR, etc), so we have to select *
-  iht.*
-FROM (
-  -- Get the read counts
-  SELECT
-    Data.AnimalId,
-    SUM(Data.TotalReads) AS TotalReads,
-    SUM(Data.IdentifiedReads) AS TotalIdentifiedReads,
-    CAST(CASE WHEN SUM(Data.TotalReads) = 0 THEN NULL ELSE ((1.0 - CAST(SUM(Data.IdentifiedReads) AS DOUBLE) / CAST(SUM(Data.TotalReads) AS DOUBLE)) * 100.0) END AS DOUBLE) AS TotalPercentUnknown
-  FROM
-    Data
-  WHERE Data.Enabled = TRUE
-  GROUP BY Data.AnimalId
-) Summary
-JOIN genotyping.Animal AS a ON a.RowId = Summary.AnimalId
-JOIN (
-  -- Get all the haplotype assignments, pivoted by type (A, B, DR, STR, etc)
-  SELECT
-    aa.AnimalId AS HiddenAnimalId @Hidden, -- Hide so that we only get a single AnimalId column
-    MIN(CASE WHEN aha.DiploidNumber = 1 THEN h.Name ELSE NULL END) AS Haplotype1,
-    MIN(CASE WHEN aha.DiploidNumber = 2 THEN h.Name ELSE NULL END) AS Haplotype2,
-    h.Type AS Type
-  FROM genotyping.AnimalHaplotypeAssignment AS aha
-  JOIN genotyping.Haplotype AS h ON aha.HaplotypeId = h.RowId
-  JOIN genotyping.AnimalAnalysis AS aa ON aha.AnimalAnalysisId= aa.RowId
-  WHERE aa.Enabled = TRUE
-  GROUP BY aa.AnimalId, h.Type
-  PIVOT Haplotype1, Haplotype2 BY Type
-  ) iht
-ON Summary.AnimalId = iht.HiddenAnimalId
-JOIN (
-  SELECT
-    MAX(AssignmentCount) AS AssignmentCount,
-    HiddenAnimalId @Hidden
-  FROM (
-    SELECT
-      aa.AnimalId AS HiddenAnimalId @Hidden, -- Hide so that we only get a single AnimalId column
-      COUNT (DISTINCT h.Name) AS AssignmentCount @Hidden
-    FROM genotyping.AnimalHaplotypeAssignment AS aha
-    JOIN genotyping.Haplotype AS h ON aha.HaplotypeId = h.RowId
-    JOIN genotyping.AnimalAnalysis AS aa ON aha.AnimalAnalysisId= aa.RowId
-    WHERE aa.Enabled = TRUE
-    GROUP BY aa.AnimalId, h.Type
-  ) X
-  GROUP BY HiddenAnimalId
-) ac
-ON Summary.AnimalId = ac.HiddenAnimalId
+
+    Summary.AnimalId,
+    Summary.TotalReads,
+    Summary.TotalIdentifiedReads,
+    Summary.TotalPercentUnknown,
+
+    a.ConcatenatedHaplotypes,
+    CASE WHEN iht.AssignmentCount > 2 THEN TRUE ELSE FALSE END AS InconsistentAssignments,
+    iht.AssignmentCount,
+    -- We don't know the names of all of the haplotype types (A, B, DR, STR, etc), so we have to select *
+    iht.*
+FROM
+    genotyping.Animal AS a
+
+        JOIN (
+        -- Get all the haplotype assignments, pivoted by type (A, B, DR, STR, etc)
+        SELECT
+            HiddenAnimalId @Hidden,
+            MIN(Haplotype1) AS Haplotype1,
+            MIN(Haplotype2) AS Haplotype2,
+            MIN(AssignmentCount) AS AssignmentCount @Hidden,
+                Type
+        FROM (
+                 SELECT
+                     aa.AnimalId AS HiddenAnimalId @Hidden, -- Hide so that we only get a single AnimalId column
+                         MIN(CASE WHEN aha.DiploidNumber = 1 THEN h.Name ELSE NULL END) AS Haplotype1,
+                     MIN(CASE WHEN aha.DiploidNumber = 2 THEN h.Name ELSE NULL END) AS Haplotype2,
+                     COUNT (DISTINCT h.Name) AS AssignmentCount @Hidden,
+                         h.Type AS Type
+                 FROM genotyping.AnimalHaplotypeAssignment AS aha
+                          JOIN genotyping.Haplotype AS h ON aha.HaplotypeId = h.RowId
+                          JOIN genotyping.AnimalAnalysis AS aa ON aha.AnimalAnalysisId= aa.RowId
+                 WHERE aa.Enabled = TRUE
+                 GROUP BY aa.AnimalId, h.Type
+             ) x
+        GROUP BY HiddenAnimalId, Type
+            PIVOT Haplotype1, Haplotype2 BY Type
+    ) iht
+             ON a.RowId = iht.HiddenAnimalId
+
+        JOIN (
+        -- Get the read counts
+        SELECT
+            AnimalId,
+            SUM(TotalReads) AS TotalReads,
+            SUM(IdentifiedReads) AS TotalIdentifiedReads,
+            CAST(CASE WHEN SUM(TotalReads) = 0 THEN NULL ELSE ((1.0 - CAST(SUM(IdentifiedReads) AS DOUBLE) / CAST(SUM(TotalReads) AS DOUBLE)) * 100.0) END AS DOUBLE) AS TotalPercentUnknown
+        FROM
+            Data
+        WHERE Enabled = TRUE
+        GROUP BY AnimalId
+    ) Summary
+             ON a.RowId = Summary.AnimalId

--- a/genotyping/resources/assay/Haplotype/queries/AggregatedAnalysisResults.sql
+++ b/genotyping/resources/assay/Haplotype/queries/AggregatedAnalysisResults.sql
@@ -52,7 +52,7 @@ FROM
                  GROUP BY aa.AnimalId, h.Type
              ) x
         GROUP BY HiddenAnimalId, Type
-            PIVOT Haplotype1, Haplotype2 BY Type
+            PIVOT Haplotype1, Haplotype2 BY Type IN (SELECT DISTINCT Type FROM genotyping.Haplotype)
     ) iht
              ON a.RowId = iht.HiddenAnimalId
 


### PR DESCRIPTION
#### Rationale
The grid for this query is taking ~7 minutes to render. We can do better. This change takes it down to ~15 seconds. Still slower than I'd like, but a big improvement.

#### Changes
* Avoid doing expensive GROUP BY twice
* Reorder the JOINs based on the fastest subquery