### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/genotyping/src/org/labkey/genotyping/IlluminaFastqParser.java
+++ b/genotyping/src/org/labkey/genotyping/IlluminaFastqParser.java
@@ -395,7 +395,7 @@ public class IlluminaFastqParser
         @Before
         public void preTest() throws Exception
         {
-            container = ContainerManager.createContainer(JunitUtil.getTestContainer(), FOLDER_NAME);
+            container = ContainerManager.createContainer(JunitUtil.getTestContainer(), FOLDER_NAME, TestContext.get().getUser());
 
             FileContentService svc = FileContentService.get();
             _testRoot = svc.getFileRoot(container);


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers