### PR TITLE
Fix crawler test failure due to unexpected alert

### DIFF
--- a/genotyping/resources/views/illuminaSampleSheetExport.html
+++ b/genotyping/resources/views/illuminaSampleSheetExport.html
@@ -7,7 +7,7 @@
 Ext4.onReady(function(){
     var webpart = <%=webpartContext%>;
 
-    var pks = LABKEY.ActionURL.getParameterArray('pks');
+    var pks = LABKEY.ActionURL.getParameterArray('pks') || [];
     var schemaName = 'lists';
     var queryName = 'Samples';
 
@@ -26,7 +26,12 @@ Ext4.onReady(function(){
                  }).render(webpart.wrapperDivId);
              }
              else {
-                 alert('No rows found')
+                 Ext4.Msg.show({
+                     title:'ERROR',
+                     msg: 'No rows found',
+                     buttons: Ext4.Msg.OK,
+                     icon: Ext4.MessageBox.ERROR
+                 });
              }
          }
      });


### PR DESCRIPTION
#### Rationale
The post-test crawler treats unexpected alert dialogs as failures. Stop presenting them to help reduce test noise.

Example failure:

https://teamcity.labkey.org/viewLog.html?buildId=2796872&tab=buildResultsDiv&buildTypeId=bt401

#### Changes
* Convert alert to an Ext message dialog