### PR TITLE
Issue 49472: Improve loading of JS dependencies

### DIFF
--- a/OConnor/resources/views/AnimalList.html
+++ b/OConnor/resources/views/AnimalList.html
@@ -1,9 +1,6 @@
 
 <script type="text/javascript">
 
-LABKEY.requiresScript('oconnor/moreInfo.js');
-	
-	
 Ext.onReady(main);
 
 function main(){

--- a/OConnor/resources/views/AnimalList.view.xml
+++ b/OConnor/resources/views/AnimalList.view.xml
@@ -3,5 +3,7 @@
        frame="none"
        >
        
-       
+       <dependencies>
+              <dependency path="oconnor/moreInfo.js" />
+       </dependencies>
 </view>

--- a/OConnor/resources/views/BloodDraws.html
+++ b/OConnor/resources/views/BloodDraws.html
@@ -1,8 +1,6 @@
 
 <script type="text/javascript">
 
-LABKEY.requiresScript('oconnor/moreInfo.js');
-	
 Ext.onReady(main);
 
 function main(){

--- a/OConnor/resources/views/BloodDraws.view.xml
+++ b/OConnor/resources/views/BloodDraws.view.xml
@@ -2,6 +2,8 @@
        title="Blood Draws"
        frame="none"
        >
-       
-       
+
+       <dependencies>
+              <dependency path="oconnor/moreInfo.js" />
+       </dependencies>
 </view>

--- a/OConnor/resources/views/Elispot_Matrix.html
+++ b/OConnor/resources/views/Elispot_Matrix.html
@@ -1,8 +1,6 @@
 <html>
 <script type="text/javascript">
 
-LABKEY.requiresScript('oconnor/oconnorFunctions.js');
-
 function toExperiment(experiment){
 
     LABKEY.Query.selectRows({

--- a/OConnor/resources/views/Elispot_Matrix.view.xml
+++ b/OConnor/resources/views/Elispot_Matrix.view.xml
@@ -2,6 +2,9 @@
        title="Matrix ELISpot Analysis"
        frame="none"
        >
-       
-       
+
+       <dependencies>
+              <dependency path="oconnor/oconnorFunctions.js" />
+       </dependencies>
+
 </view>

--- a/OConnor/resources/views/add_keyword.html
+++ b/OConnor/resources/views/add_keyword.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 var pageButtons = [{text: 'Add Keyword', requiresSelection: true, handler: addKeyword}];

--- a/OConnor/resources/views/add_keyword.view.xml
+++ b/OConnor/resources/views/add_keyword.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/all_purchases.html
+++ b/OConnor/resources/views/all_purchases.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 createGrid(dbSchemaName, 'all_orders', 'all', '', 'a', 'b','');

--- a/OConnor/resources/views/all_purchases.view.xml
+++ b/OConnor/resources/views/all_purchases.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/enabled_grants.html
+++ b/OConnor/resources/views/enabled_grants.html
@@ -2,12 +2,6 @@
 <head>
 
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function()
 {
 var pageButtons = [{text: 'Add New Grant', handler: addGrant}];

--- a/OConnor/resources/views/enabled_grants.view.xml
+++ b/OConnor/resources/views/enabled_grants.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/enabled_shipping.html
+++ b/OConnor/resources/views/enabled_shipping.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function()
 {
 var pageButtons = [{text: 'New Shipping Address', handler: newAddress}];

--- a/OConnor/resources/views/enabled_shipping.view.xml
+++ b/OConnor/resources/views/enabled_shipping.view.xml
@@ -1,2 +1,6 @@
-<view xmlns="http://labkey.org/data/xml/view" frame="none"> 
+<view xmlns="http://labkey.org/data/xml/view" frame="none">
+    <dependencies>
+        <dependency path="oconnor/oconnorAlabrityConfig.js" />
+        <dependency path="oconnor/oconnorPurchaseCommon.js" />
+    </dependencies>
 </view>

--- a/OConnor/resources/views/enabled_vendor_quotes.html
+++ b/OConnor/resources/views/enabled_vendor_quotes.html
@@ -2,12 +2,6 @@
 <head>
 
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function()
 {
 var pageButtons = [{text: 'Add New Vendor Quote', handler: addQuote}];

--- a/OConnor/resources/views/enabled_vendor_quotes.view.xml
+++ b/OConnor/resources/views/enabled_vendor_quotes.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/enabled_vendors.html
+++ b/OConnor/resources/views/enabled_vendors.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 //draw grid for all vendors
 

--- a/OConnor/resources/views/enabled_vendors.view.xml
+++ b/OConnor/resources/views/enabled_vendors.view.xml
@@ -1,2 +1,6 @@
-<view xmlns="http://labkey.org/data/xml/view" frame="none"> 
+<view xmlns="http://labkey.org/data/xml/view" frame="none">
+    <dependencies>
+        <dependency path="oconnor/oconnorAlabrityConfig.js" />
+        <dependency path="oconnor/oconnorPurchaseCommon.js" />
+    </dependencies>
 </view>

--- a/OConnor/resources/views/grant_summary.html
+++ b/OConnor/resources/views/grant_summary.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 //wait until page contents load
 Ext.onReady(function(){
 	

--- a/OConnor/resources/views/grant_summary.view.xml
+++ b/OConnor/resources/views/grant_summary.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/inventory_all_samples.html
+++ b/OConnor/resources/views/inventory_all_samples.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorFreezerCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 createGrid(dbSchemaName, 'inventory', 'all_samples', 'Inventory', 'a', 'b','');

--- a/OConnor/resources/views/inventory_all_samples.view.xml
+++ b/OConnor/resources/views/inventory_all_samples.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorFreezerCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/inventory_cells_available.html
+++ b/OConnor/resources/views/inventory_cells_available.html
@@ -1,15 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorFreezerCommon.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/inventoryDrawCellsLayout.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 //add custom button to add specimens to inventory

--- a/OConnor/resources/views/inventory_cells_available.view.xml
+++ b/OConnor/resources/views/inventory_cells_available.view.xml
@@ -1,0 +1,7 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorFreezerCommon.js" />
+              <dependency path="oconnor/inventoryDrawCellsLayout.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/inventory_dna_available.html
+++ b/OConnor/resources/views/inventory_dna_available.html
@@ -1,15 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorFreezerCommon.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/inventoryDrawPlasmidLayout.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 //add custom button to add specimens to inventory

--- a/OConnor/resources/views/inventory_dna_available.view.xml
+++ b/OConnor/resources/views/inventory_dna_available.view.xml
@@ -1,0 +1,7 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorFreezerCommon.js" />
+              <dependency path="oconnor/inventoryDrawPlasmidLayout.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/inventory_oligo_available.html
+++ b/OConnor/resources/views/inventory_oligo_available.html
@@ -1,15 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorFreezerCommon.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/inventoryDrawOligoLayout.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 //add custom button to add specimens to inventory

--- a/OConnor/resources/views/inventory_oligo_available.view.xml
+++ b/OConnor/resources/views/inventory_oligo_available.view.xml
@@ -1,0 +1,7 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorFreezerCommon.js" />
+              <dependency path="oconnor/inventoryDrawOligoLayout.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/inventory_virus_available.html
+++ b/OConnor/resources/views/inventory_virus_available.html
@@ -1,15 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorFreezerCommon.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/inventoryDrawVirusLayout.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 //add custom button to add specimens to inventory

--- a/OConnor/resources/views/inventory_virus_available.view.xml
+++ b/OConnor/resources/views/inventory_virus_available.view.xml
@@ -1,0 +1,7 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorFreezerCommon.js" />
+              <dependency path="oconnor/inventoryDrawVirusLayout.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/mark_cancelled.html
+++ b/OConnor/resources/views/mark_cancelled.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 var pageButtons = [{text: 'Mark as Cancelled', requiresSelection: true, handler: markCancelled}];

--- a/OConnor/resources/views/mark_cancelled.view.xml
+++ b/OConnor/resources/views/mark_cancelled.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/mark_invoiced.html
+++ b/OConnor/resources/views/mark_invoiced.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 var pageButtons = [{text: 'Mark as Invoiced', requiresSelection: true, handler: markInvoiced}];

--- a/OConnor/resources/views/mark_invoiced.view.xml
+++ b/OConnor/resources/views/mark_invoiced.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/mark_ordered.html
+++ b/OConnor/resources/views/mark_ordered.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 	
 var pageButtons = [{text: 'Mark as Ordered', requiresSelection: true, handler: markOrdered}];

--- a/OConnor/resources/views/mark_ordered.view.xml
+++ b/OConnor/resources/views/mark_ordered.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/mark_received.html
+++ b/OConnor/resources/views/mark_received.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 
 var pageButtons = [{text: 'Mark as Received', requiresSelection: true, handler: markReceived}];

--- a/OConnor/resources/views/mark_received.view.xml
+++ b/OConnor/resources/views/mark_received.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/my_purchases.html
+++ b/OConnor/resources/views/my_purchases.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 //wait until page contents load
 Ext.onReady(function(){
 	

--- a/OConnor/resources/views/my_purchases.view.xml
+++ b/OConnor/resources/views/my_purchases.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/popular_purchases.html
+++ b/OConnor/resources/views/popular_purchases.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 //wait until page contents load
 Ext.onReady(function(){
 

--- a/OConnor/resources/views/popular_purchases.view.xml
+++ b/OConnor/resources/views/popular_purchases.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>

--- a/OConnor/resources/views/purchase_item.html
+++ b/OConnor/resources/views/purchase_item.html
@@ -1,12 +1,6 @@
 <html>
 <head>
 <script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorAlabrityConfig.js");
-</script>
-<script type="text/javascript">
-LABKEY.Utils.requiresScript("oconnor/oconnorPurchaseCommon.js");
-</script>
-<script type="text/javascript">
 Ext.onReady(function(){
 //script logic
 

--- a/OConnor/resources/views/purchase_item.view.xml
+++ b/OConnor/resources/views/purchase_item.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+       <dependencies>
+              <dependency path="oconnor/oconnorAlabrityConfig.js" />
+              <dependency path="oconnor/oconnorPurchaseCommon.js" />
+       </dependencies>
+</view>


### PR DESCRIPTION
#### Rationale
We've been "lucky" for many years in terms of the timing of loading some JS dependencies for O'Connor lab views. We're no longer so lucky in 23.11, and the JS is running before the script it needs has loaded.

#### Changes
* Switch from requiresScript() call to declaring dependencies in the view.xml file