### PR TITLE
Issue 49964: Experiment database: parent id is not populating

### DIFF
--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/query/ExperimentsTable.java
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/query/ExperimentsTable.java
@@ -197,7 +197,7 @@ public class ExperimentsTable extends SimpleUserSchema.SimpleTable<OConnorExperi
         //UserSchema targetSchema = getUserSchema().getContainer().isWorkbook() ? new OConnorExperimentsUserSchema(getUserSchema().getUser(), getUserSchema().getContainer().getParent()) : getUserSchema();
         MultiValuedForeignKey parentExperimentsFk = new MultiValuedForeignKey(
                 QueryForeignKey
-                        .from(getUserSchema(), getContainerFilter())
+                        .from(getUserSchema(), getContainer().isWorkbook() ? ContainerFilter.Type.CurrentAndFirstChildren.create(getContainer().getParent(), getUserSchema().getUser()) : getContainerFilter())
                         .schema(OConnorExperimentsUserSchema.NAME, getContainer().isWorkbook() ? getContainer().getParent() : getContainer())
                         .to(OConnorExperimentsUserSchema.Table.ParentExperiments.name(), "Container", null),
                 "ParentExperiment");

--- a/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
+++ b/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
@@ -114,6 +114,10 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
         updateViaExperimentWebpart(0, null, "type3", "1,2");
         verifyExperimentWebpart(0, "updated description 3", "type3", 1, 2);
 
+        // Make sure the values round-trip if they're not explicitly set
+        updateViaExperimentWebpart(0, null, null, null);
+        verifyExperimentWebpart(0, "updated description 3", "type3", 1, 2);
+
         testBulkUpdate();
 
         // delete via the webpart


### PR DESCRIPTION
#### Rationale
Parent experiments aren't repopulating when editing an existing experiment.

#### Changes
* Fix container filter so parent experiments resolve from inside a workbook/experiment