### PR TITLE
Migrate .view.xml files from deprecated <permissions> elements

### DIFF
--- a/OConnorExperiments/resources/views/experimentField.view.xml
+++ b/OConnorExperiments/resources/views/experimentField.view.xml
@@ -1,9 +1,9 @@
 <view xmlns="http://labkey.org/data/xml/view"
         title="Experiment Overview"
         frame="none">
-    <permissions>
-        <permission name="read"/>
-    </permissions>
+    <permissionClasses>
+        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+    </permissionClasses>
     <dependencies>
         <dependency path="Ext4"/>
         <dependency path="/ocexp/internal/Experiment.js"/>


### PR DESCRIPTION
#### Rationale
Backport fixes to calm aggressive warnings