### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/OConnorExperiments/resources/views/experimentField.view.xml
+++ b/OConnorExperiments/resources/views/experimentField.view.xml
@@ -1,9 +1,9 @@
 <view xmlns="http://labkey.org/data/xml/view"
         title="Experiment Overview"
         frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4"/>
         <dependency path="/ocexp/internal/Experiment.js"/>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.