### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/genotyping/src/org/labkey/genotyping/GenotypingController.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingController.java
@@ -385,7 +385,7 @@ public class GenotypingController extends SpringActionController
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
             ActionURL begin = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(getContainer());
-            return form.getReturnURLHelper(begin);
+            return form.getReturnUrlHelper(begin);
         }
     }
 
@@ -494,18 +494,18 @@ public class GenotypingController extends SpringActionController
     }
 
 
-    private ActionURL getAdminURL(String message, ActionURL returnURL)
+    private ActionURL getAdminURL(String message, ActionURL returnUrl)
     {
-        ActionURL url = getAdminURL(getContainer(), returnURL);
+        ActionURL url = getAdminURL(getContainer(), returnUrl);
         url.addParameter("message", message);
         return url;
     }
 
 
-    public static ActionURL getAdminURL(Container c, ActionURL returnURL)
+    public static ActionURL getAdminURL(Container c, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(AdminAction.class, c);
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -684,10 +684,10 @@ public class GenotypingController extends SpringActionController
     }
 
 
-    public static ActionURL getMySettingsURL(Container c, ActionURL returnURL)
+    public static ActionURL getMySettingsURL(Container c, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(MySettingsAction.class, c);
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -752,7 +752,7 @@ public class GenotypingController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(MySettingsForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
@@ -1110,7 +1110,7 @@ public class GenotypingController extends SpringActionController
     {
         ActionURL url = new ActionURL(AnalyzeAction.class, getContainer());
         url.addParameter("run", runId);
-        url.addReturnURL(cancelURL);
+        url.addReturnUrl(cancelURL);
         return url;
     }
 
@@ -1232,13 +1232,13 @@ public class GenotypingController extends SpringActionController
     {
         private final SortedSet<CustomView> _sequencesViews;
         private final Map<Integer, Pair<String, String>> _sampleMap;
-        private final ActionURL _returnURL;
+        private final ActionURL _returnUrl;
 
-        private AnalyzeBean(SortedSet<CustomView> sequenceViews, Map<Integer, Pair<String, String>> sampleMap, ActionURL returnURL)
+        private AnalyzeBean(SortedSet<CustomView> sequenceViews, Map<Integer, Pair<String, String>> sampleMap, ActionURL returnUrl)
         {
             _sequencesViews = sequenceViews;
             _sampleMap = sampleMap;
-            _returnURL = returnURL;
+            _returnUrl = returnUrl;
         }
 
         public SortedSet<CustomView> getSequencesViews()
@@ -1251,9 +1251,9 @@ public class GenotypingController extends SpringActionController
             return _sampleMap;
         }
 
-        public ActionURL getReturnURL()
+        public ActionURL getReturnUrl()
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 
@@ -2015,13 +2015,13 @@ public class GenotypingController extends SpringActionController
     {
         private final Collection<Integer> _ids;
         private final String _assayName;
-        private final ActionURL _returnURL;
+        private final ActionURL _returnUrl;
 
-        public AssignmentReportBean(Collection<Integer> ids, String assayName, ActionURL returnURL)
+        public AssignmentReportBean(Collection<Integer> ids, String assayName, ActionURL returnUrl)
         {
             _ids = ids;
             _assayName = assayName;
-            _returnURL = returnURL;
+            _returnUrl = returnUrl;
         }
 
         public Collection<Integer> getIds()
@@ -2034,9 +2034,9 @@ public class GenotypingController extends SpringActionController
             return _assayName;
         }
 
-        public ActionURL getReturnURL()
+        public ActionURL getReturnUrl()
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 
@@ -2057,10 +2057,10 @@ public class GenotypingController extends SpringActionController
             AssayHeaderView header = new AssayHeaderView(form.getProtocol(), form.getProvider(), false, true, null);
             result.addView(header);
 
-            ActionURL returnURL = form.getReturnActionURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(getContainer()));
+            ActionURL returnUrl = form.getReturnActionURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(getContainer()));
 
-            AssignmentReportBean bean = new AssignmentReportBean(selected, _protocol.getName(), returnURL);
-            JspView report = new JspView<>("/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp", bean);
+            AssignmentReportBean bean = new AssignmentReportBean(selected, _protocol.getName(), returnUrl);
+            JspView<?> report = new JspView<>("/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp", bean);
             result.addView(report);
 
             return result;
@@ -2360,11 +2360,6 @@ public class GenotypingController extends SpringActionController
         public void setRowId(int rowId)
         {
             _rowId = rowId;
-        }
-
-        public void setSrcURL(String srcURL)
-        {
-            ReturnUrlForm.throwBadParam();
         }
     }
 }

--- a/genotyping/src/org/labkey/genotyping/view/analyze.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/analyze.jsp
@@ -133,7 +133,7 @@ var f = new LABKEY.ext.FormPanel({
         description,
         selectedSamples
     ],
-    buttons:[{text:'Submit', type:'submit', handler:submit}, {text:'Cancel', handler:function() {document.location = <%=q(bean.getReturnURL())%>;}}],
+    buttons:[{text:'Submit', type:'submit', handler:submit}, {text:'Cancel', handler:function() {document.location = <%=q(bean.getReturnUrl())%>;}}],
     buttonAlign:'left'
 });
 

--- a/genotyping/src/org/labkey/genotyping/view/configure.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/configure.jsp
@@ -39,11 +39,11 @@
 
     ActionURL animalQueryURL = QueryService.get().urlFor(getUser(), getContainer(), QueryAction.executeQuery, "genotyping", "Animal");
     ActionURL animalEditDomainURL = PropertyService.get().getDomainKind(schema.getDomainURI(GenotypingQuerySchema.TableType.Animal.name())).urlCreateDefinition(GenotypingQuerySchema.NAME, GenotypingQuerySchema.TableType.Animal.name(), getContainer(), getUser());
-    animalEditDomainURL.addReturnURL(getActionURL());
+    animalEditDomainURL.addReturnUrl(getActionURL());
 
     ActionURL haplotypeQueryURL = QueryService.get().urlFor(getUser(), getContainer(), QueryAction.executeQuery, "genotyping", "Haplotype");
     ActionURL haplotypeEditDomainURL = PropertyService.get().getDomainKind(schema.getDomainURI(GenotypingQuerySchema.TableType.Haplotype.name())).urlCreateDefinition(GenotypingQuerySchema.NAME, GenotypingQuerySchema.TableType.Haplotype.name(), getContainer(), getUser());
-    haplotypeEditDomainURL.addReturnURL(getActionURL());
+    haplotypeEditDomainURL.addReturnUrl(getActionURL());
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     var queries = {};
@@ -166,6 +166,6 @@
             </td>
         </tr>
         <tr><td>&nbsp;</td></tr>
-        <tr><td><%= button("Submit").submit(true) %> <%= button("Done").href(form.getReturnURLHelper()) %><%=generateReturnUrlFormField(form)%></td></tr>
+        <tr><td><%= button("Submit").submit(true) %> <%= button("Done").href(form.getReturnUrlHelper()) %><%=generateReturnUrlFormField(form)%></td></tr>
     </table>
 </form>

--- a/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
@@ -34,7 +34,7 @@
     GenotypingController.AssignmentForm bean = me.getModelBean();
     final String formDivId = "form" + getRequestScopedUID();
 
-    ActionURL returnURL = bean.getReturnActionURL(urlProvider(ProjectUrls.class).getBeginURL(getContainer()));
+    ActionURL returnUrl = bean.getReturnActionURL(urlProvider(ProjectUrls.class).getBeginURL(getContainer()));
 %>
 <%
     if (getErrors("form").hasErrors())
@@ -111,7 +111,7 @@
                             commands: commands,
                             success: function(data) {
                                 assignmentForm.getEl().unmask();
-                                window.location = <%=q(returnURL)%>
+                                window.location = <%=q(returnUrl)%>
                             },
                             failure: function(response) {
                                 alert(response.exception);
@@ -123,7 +123,7 @@
                 {
                     text: 'Cancel',
                     handler: function(){
-                        window.location = <%=q(returnURL)%>
+                        window.location = <%=q(returnUrl)%>
                     }
                 }
             ],

--- a/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
@@ -143,7 +143,7 @@
                 {
                     text: 'Cancel',
                     handler: function(){
-                        window.location = <%=q(bean.getReturnURL())%>;
+                        window.location = <%=q(bean.getReturnUrl())%>;
                     }
                 }
             ],

--- a/genotyping/src/org/labkey/genotyping/view/mySettings.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/mySettings.jsp
@@ -48,6 +48,6 @@
         <tr><td>&nbsp;</td></tr>
         <tr><td>Galaxy web API key</td><td><input size="40" name="galaxyKey" value="<%=h(form.getGalaxyKey())%>"></td></tr>
         <tr><td>&nbsp;</td></tr>
-        <tr><td><%= button("Submit").submit(true) %> <%= button("Cancel").href(form.getReturnURLHelper()) %><%=generateReturnUrlFormField(form)%></td></tr>
+        <tr><td><%= button("Submit").submit(true) %> <%= button("Cancel").href(form.getReturnUrlHelper()) %><%=generateReturnUrlFormField(form)%></td></tr>
     </table>
 </labkey:form>


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters