### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/OConnor/resources/assay/ELISpot_OConnor/views/results.html
+++ b/OConnor/resources/assay/ELISpot_OConnor/views/results.html
@@ -121,7 +121,7 @@ Ext.onReady(function() {
 
 	    	          ]
 	       }
-	    }).render();
+	    });
 	 	
 	 	
 	 	LABKEY.Query.selectRows({

--- a/OConnor/resources/assay/Lymphocyte/views/results.html
+++ b/OConnor/resources/assay/Lymphocyte/views/results.html
@@ -12,7 +12,7 @@ Ext.onReady(function() {
        ,dataRegionName: LABKEY.page.assay.name+" Data"
        ,frame: 'none'
 
-    }).render();
+    });
 });
 
 </script>


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders