### PR TITLE
DatabaseIdentifier

### DIFF
--- a/genotyping/src/org/labkey/genotyping/GenotypingQuerySchema.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingQuerySchema.java
@@ -67,6 +67,8 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static org.labkey.api.query.ExprColumn.STR_TABLE_ALIAS;
+
 /**
  * User: adam
  * Date: Oct 4, 2010
@@ -136,7 +138,7 @@ public class GenotypingQuerySchema extends UserSchema
             {
                 FilteredTable table = new FilteredTable<>(GS.getSequencesTable(), schema, cf);
                 table.wrapAllColumns(true);
-                SQLFragment containerCondition = new SQLFragment("(SELECT Container FROM ").append(GS.getDictionariesTable().getFromSQL("d")).append(" WHERE d.RowId = ").append(GS.getSequencesTable()).append(".Dictionary) = ?");
+                SQLFragment containerCondition = new SQLFragment("(SELECT Container FROM ").append(GS.getDictionariesTable().getFromSQL("d")).append(" WHERE d.RowId = ").append(STR_TABLE_ALIAS).append(".Dictionary) = ?");
                 containerCondition.add(schema.getContainer().getId());
                 table.addCondition(containerCondition);
                 removeFromDefaultVisibleColumns(table, "Dictionary");
@@ -270,7 +272,7 @@ public class GenotypingQuerySchema extends UserSchema
 
                 table.wrapAllColumns(true);
                 table.getMutableColumn("CreatedBy").setFk(new UserIdQueryForeignKey(schema, true));
-                SQLFragment containerCondition = new SQLFragment("(SELECT Container FROM " + GS.getRunsTable() + " r WHERE r.RowId = " + GS.getAnalysesTable() + ".Run) = ?");
+                SQLFragment containerCondition = new SQLFragment("(SELECT Container FROM " + GS.getRunsTable() + " r WHERE r.RowId = " + STR_TABLE_ALIAS + ".Run) = ?");
                 containerCondition.add(schema.getContainer().getId());
                 table.addCondition(containerCondition);
                 setDefaultVisibleColumns(table, "RowId, Run, Created, CreatedBy, Description, SequenceDictionary, SequencesView");

--- a/genotyping/src/org/labkey/genotyping/view/mhcQuery.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/mhcQuery.jsp
@@ -29,7 +29,7 @@
 SELECT  reads.sampleid,
         alleles,
         CAST(COUNT(*) AS INT) AS reads,
-        CAST(COUNT(*) AS REAL)/total_reads AS <%=dialect.getColumnSelectName("percent")%>,
+        CAST(COUNT(*) AS REAL)/total_reads AS <%=dialect.getColumnSelectName("percent").getRawSQL()%>,
         AVG(avg_length) AS avg_length,
         CAST(SUM(pos_reads) AS INT) AS pos_reads,
         CAST(SUM(neg_reads) AS INT) AS neg_reads,


### PR DESCRIPTION
#### Rationale
Generating correct sql is very dependent on everyone writing identifier consistently.  This is often handled by using append(SqlDialect.makeLegalIdentifier(col.getAlias())) or luck append(col.getName()) or append(col.getAlias()).

The idea is to pass around database identifiers such as table names, column names, both generated and from db metadata, using a class DatabaseIdentifier.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
