### PR TITLE
Issue 52824: Don't mutate domains from the cache

### DIFF
--- a/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
@@ -157,7 +157,7 @@ public class HaplotypeAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public Domain getResultsDomain(ExpProtocol protocol)
+    public Domain getResultsDomain(ExpProtocol protocol, boolean forUpdate)
     {
         return null;
     }


### PR DESCRIPTION
#### Rationale
Issue [52824](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52824)
See related PR.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6690

#### Changes
- Use new `forUpdate` parameter in various calls to get domains.
