### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/OConnorExperimentsController.java
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/OConnorExperimentsController.java
@@ -17,7 +17,6 @@
 package org.labkey.oconnorexperiments;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -93,7 +92,7 @@ public class OConnorExperimentsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -108,7 +107,7 @@ public class OConnorExperimentsController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class MigrateDataAction extends FormViewAction<UserForm>
+    public static class MigrateDataAction extends FormViewAction<UserForm>
     {
         @Override
         public void validateCommand(UserForm target, Errors errors)
@@ -234,7 +233,7 @@ public class OConnorExperimentsController extends SpringActionController
                     // Move files
                     File sourceFile = new File(fileContentService.getFileRoot(sourceContainer).getPath() + File.separator + "@files", databaseMap.get("expnumber").toString());
                     File targetDir = new File(fileContentService.getFileRoot(targetContainer).getPath() + File.separator + databaseMap.get("expnumber").toString() + File.separator + "@files");
-                    LogManager.getLogger(OConnorExperimentsController.class).info("Copy from file '" + sourceFile.toString() + "' to directory '" + targetDir.toString() +"'" );
+                    LogManager.getLogger(OConnorExperimentsController.class).info("Copy from file '" + sourceFile + "' to directory '" + targetDir +"'" );
                     if (sourceFile.exists())
                     {
                         FileUtils.copyDirectory(sourceFile, targetDir);
@@ -258,7 +257,7 @@ public class OConnorExperimentsController extends SpringActionController
                     Map<String, Object> map = new CaseInsensitiveHashMap<>();
                     map.put("container", databaseMap.get("ContainerStr"));
 
-                    String[] parents = new String[0];
+                    String[] parents;
                     ArrayList<String> parentsEntityId = new ArrayList<>();
                     if (databaseMap.get("expParent") != null)
                     {
@@ -280,9 +279,9 @@ public class OConnorExperimentsController extends SpringActionController
                                 }
                             }
                         }
-                        if (parentsEntityId.size() > 0)
+                        if (!parentsEntityId.isEmpty())
                         {
-                            map.put("ParentExperiments", parentsEntityId.toArray(new String[parentsEntityId.size()]));
+                            map.put("ParentExperiments", parentsEntityId.toArray(new String[0]));
 
                             // workaround, pass user, container - databaseMap.get("Container"), singleton list
                             LogManager.getLogger(OConnorExperimentsController.class).info("Update rows on experiment " + databaseMap.get("expnumber"));
@@ -423,7 +422,7 @@ public class OConnorExperimentsController extends SpringActionController
      */
     @RequiresLogin
     @RequiresPermission(InsertPermission.class)
-    public class InsertExperimentAction extends FormHandlerAction
+    public static class InsertExperimentAction extends FormHandlerAction<Object>
     {
         private Container newExperiment;
 
@@ -465,7 +464,7 @@ public class OConnorExperimentsController extends SpringActionController
 
     @RequiresLogin
     @RequiresPermission(ReadPermission.class)
-    public class GetExperimentAction extends ReadOnlyApiAction
+    public static class GetExperimentAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object o, BindException errors) throws Exception
@@ -474,7 +473,7 @@ public class OConnorExperimentsController extends SpringActionController
             TableInfo table = schema.getTable(OConnorExperimentsUserSchema.Table.Experiments.name());
             QueryUpdateService qus = table.getUpdateService();
 
-            List<Map<String, Object>> pks = Collections.singletonList(Collections.singletonMap("Container", (Object)getContainer().getId()));
+            List<Map<String, Object>> pks = Collections.singletonList(Collections.singletonMap("Container", getContainer().getId()));
             List<Map<String, Object>> result = qus.getRows(getUser(), getContainer(), pks);
 
             ApiSimpleResponse resp = new ApiSimpleResponse();
@@ -495,14 +494,14 @@ public class OConnorExperimentsController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class HistoryAction extends SimpleViewAction
+    public static class HistoryAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
             getPageConfig().setNoIndex();
             getPageConfig().setNoFollow();
-            return new JspView("/org/labkey/oconnorexperiments/view/history.jsp", null, errors);
+            return new JspView<>("/org/labkey/oconnorexperiments/view/history.jsp", null, errors);
         }
 
         @Override
@@ -528,7 +527,7 @@ public class OConnorExperimentsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class LookupWorkbookAction extends SimpleViewAction<LookupWorkbookForm>
+    public static class LookupWorkbookAction extends SimpleViewAction<LookupWorkbookForm>
     {
         @Override
         public ModelAndView getView(LookupWorkbookForm form, BindException errors)

--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/OConnorExperimentsModule.java
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/OConnorExperimentsModule.java
@@ -128,7 +128,7 @@ public class OConnorExperimentsModule extends DefaultModule
     }
 
     // Listener that just updates the experiment changed date when a wiki is modified.
-    private class OConnorWikiChangeListener implements WikiChangeListener
+    private static class OConnorWikiChangeListener implements WikiChangeListener
     {
         @Override
         public void wikiCreated(User user, Container c, String name)
@@ -150,7 +150,7 @@ public class OConnorExperimentsModule extends DefaultModule
     }
 
     // Listener that just updates the experiment changed date when a file is uploaded/renamed.
-    private class OConnorFileChangeListener implements FileListener
+    private static class OConnorFileChangeListener implements FileListener
     {
         @Override
         public void fileCreated(@NotNull File created, @Nullable User user, @Nullable Container container)

--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/query/ExperimentsTable.java
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/query/ExperimentsTable.java
@@ -505,7 +505,7 @@ public class ExperimentsTable extends SimpleUserSchema.SimpleTable<OConnorExperi
             }
 
             Collection<String> parentExperiments = (Collection<String>)o;
-            if (parentExperiments.size() == 0)
+            if (parentExperiments.isEmpty())
                 return true;
 
             // Validate each ParentExperiment is a workbook and create list of maps for insertion

--- a/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
+++ b/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
@@ -64,7 +64,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
     private static final String TABLE_NAME = "Experiments";
     private static final String EXPERIMENT_TYPE_TABLE_NAME = "ExperimentType";
     private static final String EXPERIMENT_SAVE_SIGNAL = "experimentDataSave"; // See experimentField.html
-    private ArrayList<String> pkeys = new ArrayList<>();
+    private final ArrayList<String> pkeys = new ArrayList<>();
 
     @Nullable
     @Override
@@ -327,7 +327,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
             DeleteRowsCommand cmd = new DeleteRowsCommand(SCHEMA_NAME, TABLE_NAME);
             Connection cn = WebTestHelper.getRemoteApiConnection();
             for (String pk : pkeys)
-                cmd.addRow(Collections.singletonMap("container", (Object) pk));
+                cmd.addRow(Collections.singletonMap("container", pk));
 
             SaveRowsResponse resp = cmd.execute(cn, getProjectName());
             assertEquals("Expected to delete " + pkeys.size() + " rows", pkeys.size(), resp.getRowsAffected().intValue());

--- a/OConnorExperiments/test/src/org/labkey/test/tests/OConnorListTest.java
+++ b/OConnorExperiments/test/src/org/labkey/test/tests/OConnorListTest.java
@@ -70,7 +70,7 @@ public class OConnorListTest extends BaseWebDriverTest implements PostgresOnlyTe
     @LogMethod
     public static void setup()
     {
-        OConnorListTest initTest = (OConnorListTest)getCurrentTest();
+        OConnorListTest initTest = getCurrentTest();
         initTest.setupOConnorProject();
     }
 

--- a/genotyping/src/org/labkey/genotyping/GenotypingController.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingController.java
@@ -154,7 +154,7 @@ public class GenotypingController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleRedirectAction
+    public static class BeginAction extends SimpleRedirectAction<Object>
     {
         @Override
         public ActionURL getRedirectURL(Object o)
@@ -222,7 +222,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class AnalysisAction extends QueryViewAction<AnalysisForm, QueryView>
+    public static class AnalysisAction extends QueryViewAction<AnalysisForm, QueryView>
     {
         private GenotypingAnalysis _analysis = null;
 
@@ -316,7 +316,7 @@ public class GenotypingController extends SpringActionController
 
     // TODO: Delete this action? No longer used?
     @RequiresPermission(DeletePermission.class)
-    public class DeleteMatchesAction extends FormHandlerAction<MatchesForm>
+    public static class DeleteMatchesAction extends FormHandlerAction<MatchesForm>
     {
         private int _count = 0;
         private String _error = null;
@@ -363,7 +363,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class LoadSequencesAction extends FormHandlerAction<ReturnUrlForm>
+    public static class LoadSequencesAction extends FormHandlerAction<ReturnUrlForm>
     {
         @Override
         public void validateCommand(ReturnUrlForm target, Errors errors)
@@ -581,7 +581,7 @@ public class GenotypingController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @IgnoresTermsOfUse
-    public class MergeFastqFilesAction extends ExportAction<MergeFastqFilesForm>
+    public static class MergeFastqFilesAction extends ExportAction<MergeFastqFilesForm>
     {
         @Override
         public void export(MergeFastqFilesForm form, HttpServletResponse response, BindException errors) throws Exception
@@ -698,7 +698,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class MySettingsAction extends FormViewAction<MySettingsForm>
+    public static class MySettingsAction extends FormViewAction<MySettingsForm>
     {
         @Override
         public void validateCommand(MySettingsForm form, Errors errors)
@@ -890,10 +890,10 @@ public class GenotypingController extends SpringActionController
 
     public static class ImportReadsBean
     {
-        private List<Integer> _runs;
-        private SEQUENCE_PLATFORMS _platform;
-        private String _readsPath;
-        private String _path;
+        private final List<Integer> _runs;
+        private final SEQUENCE_PLATFORMS _platform;
+        private final String _readsPath;
+        private final String _path;
         private String _prefix;
 
         private ImportReadsBean(List<Integer> runs, String readsPath, String path, @Nullable String platform, @Nullable String prefix)
@@ -1124,7 +1124,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(InsertPermission.class)
-    public class AnalyzeAction extends FormViewAction<AnalyzeForm>
+    public static class AnalyzeAction extends FormViewAction<AnalyzeForm>
     {
         @Override
         public void validateCommand(AnalyzeForm target, Errors errors)
@@ -1501,7 +1501,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class SequencesAction extends QueryViewAction<SequencesForm, QueryView>
+    public static class SequencesAction extends QueryViewAction<SequencesForm, QueryView>
     {
         public SequencesAction()
         {
@@ -1563,7 +1563,7 @@ public class GenotypingController extends SpringActionController
 
     @SuppressWarnings({"UnusedDeclaration"})  // URL defined on sequences.rowId column in genotyping.xml
     @RequiresPermission(ReadPermission.class)
-    public class SequenceAction extends SimpleViewAction<SequenceForm>
+    public static class SequenceAction extends SimpleViewAction<SequenceForm>
     {
         @Override
         public ModelAndView getView(SequenceForm form, BindException errors)
@@ -1607,7 +1607,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class RunsAction extends QueryViewAction<QueryExportForm, QueryView>
+    public static class RunsAction extends QueryViewAction<QueryExportForm, QueryView>
     {
         public RunsAction()
         {
@@ -1636,7 +1636,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class AnalysesAction extends QueryViewAction<QueryExportForm, QueryView>
+    public static class AnalysesAction extends QueryViewAction<QueryExportForm, QueryView>
     {
         public AnalysesAction()
         {
@@ -1727,7 +1727,7 @@ public class GenotypingController extends SpringActionController
     public static final String FASTQ_FILE_FORMAT = "FASTQ_FILE";
     public static final String FASTQ_FORMAT = "FASTQ";
 
-    private abstract class ReadsAction<FORM extends RunForm> extends QueryViewAction<FORM, QueryView>
+    private abstract static class ReadsAction<FORM extends RunForm> extends QueryViewAction<FORM, QueryView>
     {
         private static final String DATA_REGION_NAME = "Reads";
 
@@ -1905,7 +1905,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class DeleteRunsAction extends FormHandlerAction
+    public static class DeleteRunsAction extends FormHandlerAction<Object>
     {
         @Override
         public void validateCommand(Object target, Errors errors)
@@ -1936,7 +1936,7 @@ public class GenotypingController extends SpringActionController
 
 
     @RequiresPermission(DeletePermission.class)
-    public class DeleteAnalysesAction extends FormHandlerAction
+    public static class DeleteAnalysesAction extends FormHandlerAction<Object>
     {
         @Override
         public void validateCommand(Object target, Errors errors)
@@ -2036,7 +2036,7 @@ public class GenotypingController extends SpringActionController
         }
     }
 
-    public class AssignmentReportBean
+    public static class AssignmentReportBean
     {
         private final Collection<Integer> _ids;
         private final String _assayName;
@@ -2101,7 +2101,7 @@ public class GenotypingController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DuplicateAssignmentReportAction extends BaseAssayAction<ProtocolIdForm>
+    public static class DuplicateAssignmentReportAction extends BaseAssayAction<ProtocolIdForm>
     {
         private ExpProtocol _protocol;
 
@@ -2128,7 +2128,7 @@ public class GenotypingController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class STRDiscrepanciesAssignmentReportAction extends SimpleViewAction<STRDiscrepancies>
+    public static class STRDiscrepanciesAssignmentReportAction extends SimpleViewAction<STRDiscrepancies>
     {
         private ExpProtocol _protocol;
         private static final String DELIM = "[;,/]";
@@ -2355,7 +2355,7 @@ public class GenotypingController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class EditHaplotypeAssignmentAction extends SimpleViewAction<AssignmentForm>
+    public static class EditHaplotypeAssignmentAction extends SimpleViewAction<AssignmentForm>
     {
         @Override
         public ModelAndView getView(AssignmentForm form, BindException errors)

--- a/genotyping/src/org/labkey/genotyping/GenotypingManager.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingManager.java
@@ -443,7 +443,7 @@ public class GenotypingManager
         GenotypingAnalysis analysis = GenotypingManager.get().getAnalysis(c, analysisId);
 
         // Verify that matches were posted
-        if (matchIds.size() < 1)
+        if (matchIds.isEmpty())
             throw new IllegalStateException("No matches were selected");
 
         // Count the corresponding matches in the database, making sure they belong to this analysis

--- a/genotyping/src/org/labkey/genotyping/GenotypingQuerySchema.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingQuerySchema.java
@@ -151,7 +151,7 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                FilteredTable table = new FilteredTable<GenotypingQuerySchema>(GS.getReadsTable(), schema, cf)
+                FilteredTable table = new FilteredTable<>(GS.getReadsTable(), schema, cf)
                 {
                     @Override
                     protected void applyContainerFilter(ContainerFilter filter)
@@ -253,7 +253,7 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                FilteredTable table = new FilteredTable<GenotypingQuerySchema>(GS.getAnalysesTable(), schema, cf)
+                FilteredTable table = new FilteredTable<>(GS.getAnalysesTable(), schema, cf)
                 {
                     @Override
                     protected void applyContainerFilter(ContainerFilter filter)
@@ -375,7 +375,7 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(final GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                FilteredTable table = new FilteredTable<GenotypingQuerySchema>(GS.getSequenceFilesTable(), schema, cf)
+                FilteredTable table = new FilteredTable<>(GS.getSequenceFilesTable(), schema, cf)
                 {
                     @Override
                     protected void applyContainerFilter(ContainerFilter filter)
@@ -528,14 +528,14 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(final GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                FilteredTable table = new FilteredTable<GenotypingQuerySchema>(GS.getIlluminaTemplatesTable(), schema, cf)
+                FilteredTable table = new FilteredTable<>(GS.getIlluminaTemplatesTable(), schema, cf)
                 {
                     @Override
                     public QueryUpdateService getUpdateService()
                     {
                         TableInfo table = getRealTable();
                         return (table != null && table.getTableType() == DatabaseTableType.TABLE ?
-                                new DefaultQueryUpdateService(this, table):
+                                new DefaultQueryUpdateService(this, table) :
                                 null);
                     }
 
@@ -595,7 +595,7 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable table = new SimpleUserSchema.SimpleTable<GenotypingQuerySchema>(schema, GS.getAnimalAnalysisTable(), cf)
+                SimpleUserSchema.SimpleTable table = new SimpleUserSchema.SimpleTable<>(schema, GS.getAnimalAnalysisTable(), cf)
                 {
                     @Override
                     protected void applyContainerFilter(ContainerFilter filter)
@@ -645,7 +645,7 @@ public class GenotypingQuerySchema extends UserSchema
             @Override
             FilteredTable createTable(GenotypingQuerySchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable table = new SimpleUserSchema.SimpleTable<GenotypingQuerySchema>(schema, GS.getAnimalHaplotypeAssignmentTable(), cf)
+                SimpleUserSchema.SimpleTable table = new SimpleUserSchema.SimpleTable<>(schema, GS.getAnimalHaplotypeAssignmentTable(), cf)
                 {
                     @Override
                     protected void applyContainerFilter(ContainerFilter filter)
@@ -805,7 +805,7 @@ public class GenotypingQuerySchema extends UserSchema
         // We need to strip out the unassigned, empty markers
         // Example concatenated values, pre-replacement, are '~, A001, ~, B004, B023, ~'; '~, ~, ~, ~, ~, ~'
         SQLFragment concatSQL = new SQLFragment("REPLACE(REPLACE(REPLACE(");
-        concatSQL.append(table.getSqlDialect().concatenate(haplotypeSQLs.toArray(new SQLFragment[haplotypeSQLs.size()])));
+        concatSQL.append(table.getSqlDialect().concatenate(haplotypeSQLs.toArray(new SQLFragment[0])));
         concatSQL.append(", '" + NULL_HAPLOTYPE_MARKER + ", ', ''), ', " + NULL_HAPLOTYPE_MARKER + "', ''), '" + NULL_HAPLOTYPE_MARKER + "', '')");
 
         ExprColumn result = new ExprColumn(table, "ConcatenatedHaplotypes", concatSQL, JdbcType.VARCHAR);

--- a/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeAssayProvider.java
@@ -133,7 +133,7 @@ public class HaplotypeAssayProvider extends AbstractAssayProvider
     }
 
     @Override
-    public HttpView getDataDescriptionView(AssayRunUploadForm form)
+    public HttpView<?> getDataDescriptionView(AssayRunUploadForm form)
     {
         return new HtmlView("");
     }

--- a/genotyping/src/org/labkey/genotyping/HaplotypeDataCollector.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeDataCollector.java
@@ -86,10 +86,10 @@ public class HaplotypeDataCollector<ContextType extends AssayRunUploadContext<Ha
         for (Map.Entry<String, HaplotypeColumnMappingProperty> property : HaplotypeAssayProvider.getColumnMappingProperties(protocol).entrySet())
         {
             String value = context.getRequest().getParameter(property.getKey());
-            if (property.getValue().isRequired() && (value == null || value.equals("")))
+            if (property.getValue().isRequired() && (value == null || value.isEmpty()))
                 errorColHeaders.add(property.getValue().getLabel());
         }
-        if (errorColHeaders.size() > 0)
+        if (!errorColHeaders.isEmpty())
         {
             throw new ExperimentException("Column header mapping missing for: " + StringUtils.join(errorColHeaders, ", "));
         }

--- a/genotyping/src/org/labkey/genotyping/HaplotypeDataHandler.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeDataHandler.java
@@ -218,7 +218,7 @@ public class HaplotypeDataHandler extends AbstractExperimentDataHandler
             {
                 // insert the new animal row
                 BatchValidationException errors = new BatchValidationException();
-                List<Map<String, Object>> insertedRow = updateService.insertRows(user, container, Collections.singletonList(row), errors, null, new HashMap<String, Object>());
+                List<Map<String, Object>> insertedRow = updateService.insertRows(user, container, Collections.singletonList(row), errors, null, new HashMap<>());
                 throwFirstError(errors);
                 if (insertedRow.size() != 1)
                 {
@@ -291,7 +291,7 @@ public class HaplotypeDataHandler extends AbstractExperimentDataHandler
             {
                 // insert the new haplotype row
                 BatchValidationException errors = new BatchValidationException();
-                List<Map<String, Object>> insertedRow = updateService.insertRows(user, container, Collections.singletonList(row), errors, null, new HashMap<String, Object>());
+                List<Map<String, Object>> insertedRow = updateService.insertRows(user, container, Collections.singletonList(row), errors, null, new HashMap<>());
                 throwFirstError(errors);
                 if (insertedRow.size() != 1)
                 {
@@ -352,7 +352,7 @@ public class HaplotypeDataHandler extends AbstractExperimentDataHandler
         }
 
         BatchValidationException errors = new BatchValidationException();
-        List<Map<String, Object>> insertedRows = updateService.insertRows(user, container, rows, errors, null, new HashMap<String, Object>());
+        List<Map<String, Object>> insertedRows = updateService.insertRows(user, container, rows, errors, null, new HashMap<>());
         throwFirstError(errors);
 
          // return a mapping from the AnimalId to the AnimalAnalysis RowId
@@ -452,7 +452,7 @@ public class HaplotypeDataHandler extends AbstractExperimentDataHandler
         }
 
         BatchValidationException errors = new BatchValidationException();
-        List<Map<String, Object>> insertedRows = updateService.insertRows(user, container, rows, errors, null, new HashMap<String, Object>());
+        List<Map<String, Object>> insertedRows = updateService.insertRows(user, container, rows, errors, null, new HashMap<>());
         throwFirstError(errors);
     }
 
@@ -522,9 +522,9 @@ public class HaplotypeDataHandler extends AbstractExperimentDataHandler
     }
 
     /** Correponds to a single animal's row in the incoming TSV */
-    public class HaplotypeAssignmentDataRow
+    public static class HaplotypeAssignmentDataRow
     {
-        private Map<String, String> _dataMap = new HashMap<>();
+        private final Map<String, String> _dataMap = new HashMap<>();
 
         public void addToDataMap(String key, String value)
         {

--- a/genotyping/src/org/labkey/genotyping/HaplotypeProtocolSchema.java
+++ b/genotyping/src/org/labkey/genotyping/HaplotypeProtocolSchema.java
@@ -102,7 +102,7 @@ public class HaplotypeProtocolSchema extends AssayProtocolSchema
     @Override
     public @Nullable TableInfo createDataTable(ContainerFilter cf, boolean includeCopiedToStudyColumns)
     {
-        FilteredTable table = (FilteredTable)new GenotypingQuerySchema(getUser(), getContainer()).getTable(GenotypingQuerySchema.TableType.AnimalAnalysis.name(), cf,true, true);
+        FilteredTable<?> table = (FilteredTable)new GenotypingQuerySchema(getUser(), getContainer()).getTable(GenotypingQuerySchema.TableType.AnimalAnalysis.name(), cf,true, true);
         List<FieldKey> keys = new ArrayList<>(table.getDefaultVisibleColumns());
         HashSet<String> defaults = HaplotypeAssayProvider.getDefaultColumns();
         List<? extends DomainProperty> props = HaplotypeAssayProvider.getDomainProps(getProtocol());
@@ -132,7 +132,7 @@ public class HaplotypeProtocolSchema extends AssayProtocolSchema
 
         table.setDefaultVisibleColumns(keys);
 
-        table.getMutableColumn("RunId").setFk(new LookupForeignKey()
+        table.getMutableColumnOrThrow("RunId").setFk(new LookupForeignKey()
         {
             @Override
             public TableInfo getLookupTableInfo()
@@ -143,7 +143,7 @@ public class HaplotypeProtocolSchema extends AssayProtocolSchema
         return table;
     }
 
-    private ExprColumn makeColumnFromRunField(DomainProperty prop, boolean max, SQLFragment selectStatement, FilteredTable table){
+    private ExprColumn makeColumnFromRunField(DomainProperty prop, boolean max, SQLFragment selectStatement, FilteredTable<?> table){
 
         String field = prop.getName();
         String label = prop.getLabel() != null ? prop.getLabel() : ColumnInfo.labelFromName(prop.getName());

--- a/genotyping/src/org/labkey/genotyping/IlluminaFastqParser.java
+++ b/genotyping/src/org/labkey/genotyping/IlluminaFastqParser.java
@@ -64,13 +64,13 @@ import java.util.Set;
  */
 public class IlluminaFastqParser
 {
-    private String _outputPrefix;
-    private Map<Integer, Integer> _sampleIndexToIdMap;
-    private Map<Integer, Integer> _sampleIdToIndexMap;
-    private Map<String, Integer> _sampleNameToIdMap;
-    private List<File> _files;
-    private Map<Pair<Integer, Integer>, FileInfo> _fileInfo = new HashMap<>();
-    private Logger _logger;
+    private final String _outputPrefix;
+    private final Map<Integer, Integer> _sampleIndexToIdMap;
+    private final Map<Integer, Integer> _sampleIdToIndexMap;
+    private final Map<String, Integer> _sampleNameToIdMap;
+    private final List<File> _files;
+    private final Map<Pair<Integer, Integer>, FileInfo> _fileInfo = new HashMap<>();
+    private final Logger _logger;
 
     public IlluminaFastqParser(@Nullable String outputPrefix, Map<Integer, Integer> sampleIndexToIdMap, Map<Integer, Integer> sampleIdToIndexMap, Map<String, Integer> sampleNameToIdMap, Logger logger, List<File> files)
     {

--- a/genotyping/src/org/labkey/genotyping/Import454ReadsJob.java
+++ b/genotyping/src/org/labkey/genotyping/Import454ReadsJob.java
@@ -151,7 +151,7 @@ public class Import454ReadsJob extends ReadsJob
 
             columns.add(new ColumnDescriptor("run", Integer.class, _run.getRowId()));
             columns.add(new ColumnDescriptor("sampleid", Integer.class));
-            loader.setColumns(columns.toArray(new ColumnDescriptor[columns.size()]));
+            loader.setColumns(columns.toArray(new ColumnDescriptor[0]));
 
             SampleManager.SampleIdFinder finder = new SampleManager.SampleIdFinder(_run, getUser(), sampleKeyColumns, "importing reads");
 

--- a/genotyping/src/org/labkey/genotyping/ImportIlluminaReadsJob.java
+++ b/genotyping/src/org/labkey/genotyping/ImportIlluminaReadsJob.java
@@ -144,7 +144,7 @@ public class ImportIlluminaReadsJob extends ReadsJob
                 Map<String, Integer> sampleNameToIdMap = new HashMap<>();
                 sampleIndexToIdMap.put(0, 0); //placeholder for control and unmapped reads
                 sampleIdToIndexMap.put(0, 0);
-                Boolean inSamples = false;
+                boolean inSamples = false;
                 int sampleIdx = 0;
 
                 while ((nextLine = reader.readNext()) != null)
@@ -206,7 +206,7 @@ public class ImportIlluminaReadsJob extends ReadsJob
                     _fastqFiles = IlluminaFastqParser.inferIlluminaInputsFromPath(_sampleFile.getParent(), _fastqPrefix);
                 }
 
-                if (_fastqFiles.size() == 0)
+                if (_fastqFiles.isEmpty())
                 {
                     throw new PipelineJobException("No FASTQ files" + (_fastqPrefix == null ? "" : " matching the prefix '" + _fastqPrefix) + "' were found");
                 }

--- a/genotyping/src/org/labkey/genotyping/ImportPacBioReadsJob.java
+++ b/genotyping/src/org/labkey/genotyping/ImportPacBioReadsJob.java
@@ -60,9 +60,9 @@ public class ImportPacBioReadsJob extends ReadsJob
 {
     private File _sampleFile;
     private String _fastqPrefix;
-    private List<PacBioPool> _pools = new LinkedList<>();
-    private String _dirSubstring = "pool";
-    private String[] _extensions = {"fastq.gz", "fastq"};
+    private final List<PacBioPool> _pools = new LinkedList<>();
+    private final String _dirSubstring = "pool";
+    private final String[] _extensions = {"fastq.gz", "fastq"};
 
     // For serialization
     protected ImportPacBioReadsJob() {}
@@ -332,7 +332,7 @@ public class ImportPacBioReadsJob extends ReadsJob
         return totalReads;
     }
 
-    class PacBioPool
+    static class PacBioPool
     {
         int poolNum;
         List<File> fastqFiles = new ArrayList<>();

--- a/genotyping/src/org/labkey/genotyping/ReadsPipelineProvider.java
+++ b/genotyping/src/org/labkey/genotyping/ReadsPipelineProvider.java
@@ -30,7 +30,7 @@ import java.io.FileFilter;
 public class ReadsPipelineProvider extends PipelineProvider
 {
     String _platform;
-    FileFilter _readsFilter = null;
+    FileFilter _readsFilter;
 
     public ReadsPipelineProvider(String name, Module owningModule, String platform)
     {

--- a/genotyping/src/org/labkey/genotyping/Status.java
+++ b/genotyping/src/org/labkey/genotyping/Status.java
@@ -40,9 +40,9 @@ public enum Status
         return _map.get(statusId);
     }
 
-    private int _statusId;
+    private final int _statusId;
 
-    private Status(int statusId)
+    Status(int statusId)
     {
         _statusId = statusId;
     }

--- a/genotyping/src/org/labkey/genotyping/SubmitAnalysisJob.java
+++ b/genotyping/src/org/labkey/genotyping/SubmitAnalysisJob.java
@@ -43,7 +43,6 @@ import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.HashMap;

--- a/genotyping/src/org/labkey/genotyping/galaxy/GalaxyServer.java
+++ b/genotyping/src/org/labkey/genotyping/galaxy/GalaxyServer.java
@@ -167,7 +167,7 @@ public class GalaxyServer
     }
 
 
-    public class Item
+    public static class Item
     {
         private final ItemType _type;
         private final String _apiUrl;

--- a/genotyping/src/org/labkey/genotyping/sequences/AlleleFastaLoader.java
+++ b/genotyping/src/org/labkey/genotyping/sequences/AlleleFastaLoader.java
@@ -28,7 +28,8 @@ public class AlleleFastaLoader extends FastaLoader<Allele>
 {
     protected AlleleFastaLoader(File fastaFile)
     {
-        super(fastaFile, new FastaIteratorElementFactory<Allele>() {
+        super(fastaFile, new FastaIteratorElementFactory<>()
+        {
             @Override
             public Allele createNext(String header, byte[] body)
             {

--- a/genotyping/src/org/labkey/genotyping/sequences/SequenceManager.java
+++ b/genotyping/src/org/labkey/genotyping/sequences/SequenceManager.java
@@ -30,7 +30,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryHelper;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.writer.FastaEntry;
 import org.labkey.api.writer.FastaWriter;

--- a/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/editHaplotypeAssignment.jsp
@@ -30,7 +30,7 @@
     }
 %>
 <%
-    JspView<GenotypingController.AssignmentForm> me = (JspView<GenotypingController.AssignmentForm>) HttpView.currentView();
+    JspView<GenotypingController.AssignmentForm> me = HttpView.currentView();
     GenotypingController.AssignmentForm bean = me.getModelBean();
     final String formDivId = "form" + getRequestScopedUID();
 

--- a/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/haplotypeAssignmentReport.jsp
@@ -30,7 +30,7 @@
     }
 %>
 <%
-    JspView<GenotypingController.AssignmentReportBean> me = (JspView<GenotypingController.AssignmentReportBean>) HttpView.currentView();
+    JspView<GenotypingController.AssignmentReportBean> me = HttpView.currentView();
     GenotypingController.AssignmentReportBean bean = me.getModelBean();
     final String idEntryFormDivId = "idEntryForm" + getRequestScopedUID();
     final String queryWebPartDivId = "queryWebPart" + getRequestScopedUID();

--- a/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
+++ b/genotyping/src/org/labkey/genotyping/view/importHaplotypeAssignments.jsp
@@ -26,11 +26,11 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<HaplotypeProtocolBean> me = (JspView<HaplotypeProtocolBean>) HttpView.currentView();
+    JspView<HaplotypeProtocolBean> me = HttpView.currentView();
     HaplotypeProtocolBean bean = me.getModelBean();
     HaplotypeDataCollector dataCollector = bean.getDataCollector();
     String[] reshowData = {};
-    if (dataCollector.getReshowValue("data") != null && !dataCollector.getReshowValue("data").equals(""))
+    if (dataCollector.getReshowValue("data") != null && !dataCollector.getReshowValue("data").isEmpty())
     {
         reshowData = dataCollector.getReshowValue("data").split("\\r?\\n");
     }

--- a/genotyping/test/src/org/labkey/test/tests/GenotypingBaseTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/GenotypingBaseTest.java
@@ -134,7 +134,7 @@ abstract public class GenotypingBaseTest extends BaseWebDriverTest implements Po
     {
         Connection cn = WebTestHelper.getRemoteApiConnection();
         DeleteRowsCommand cmd = new DeleteRowsCommand("genotyping", "IlluminaTemplates");
-        cmd.addRow(Collections.singletonMap("Name", (Object) TEMPLATE_NAME));
+        cmd.addRow(Collections.singletonMap("Name", TEMPLATE_NAME));
         SaveRowsResponse resp;
         try
         {

--- a/genotyping/test/src/org/labkey/test/tests/GenotypingTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/GenotypingTest.java
@@ -45,7 +45,7 @@ public class GenotypingTest extends GenotypingBaseTest
     @BeforeClass
     public static void setupProject()
     {
-        GenotypingTest init = (GenotypingTest)getCurrentTest();
+        GenotypingTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -65,7 +65,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
     @BeforeClass
     public static void setupProject()
     {
-        HaplotypeAssayTest init = (HaplotypeAssayTest)getCurrentTest();
+        HaplotypeAssayTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/genotyping/test/src/org/labkey/test/tests/IlluminaTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/IlluminaTest.java
@@ -60,7 +60,7 @@ public class IlluminaTest extends GenotypingBaseTest
     @BeforeClass
     public static void setupProject()
     {
-        IlluminaTest init = (IlluminaTest)getCurrentTest();
+        IlluminaTest init = getCurrentTest();
         init.doSetup();
     }
 
@@ -213,8 +213,8 @@ public class IlluminaTest extends GenotypingBaseTest
         ZIP("ZIP Archive of Individual Files", ".zip"),
         FASTQ("Merge into Single FASTQ File", ".fastq.gz");
 
-        private String _radioLabel;
-        private String _fileSuffix;
+        private final String _radioLabel;
+        private final String _fileSuffix;
 
         ExportType(String radioLabel, String fileSuffix)
         {
@@ -415,7 +415,7 @@ public class IlluminaTest extends GenotypingBaseTest
 
     }
 
-    private class OutputFilter implements FilenameFilter
+    private static class OutputFilter implements FilenameFilter
     {
         @Override
         public boolean accept(File dir, String name)
@@ -431,7 +431,7 @@ public class IlluminaTest extends GenotypingBaseTest
 
         assertEquals(30, files.length);
         DataRegionTable d = new DataRegionTable("Reads", this);
-        assertEquals(d.getDataRowCount(), 30);
+        assertEquals(30, d.getDataRowCount());
         assertTextPresent("Read Count");
         assertEquals("9", d.getDataAsText(d.getIndexWhereDataAppears("IlluminaSamples-R1-4947.fastq.gz", "Filename") + 1, "Read Count"));
     }

--- a/genotyping/test/src/org/labkey/test/tests/PacBioTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/PacBioTest.java
@@ -47,23 +47,23 @@ public class PacBioTest extends GenotypingBaseTest
     private static final String PAC_BIO_RUN = "2";
 
     private static final Map<Integer, List<String>> POOL1_DATA =
-            Collections.unmodifiableMap(new HashMap<Integer, List<String>>()
+            Collections.unmodifiableMap(new HashMap<>()
             {{
-                    put(0, Arrays.asList("lbc1--lbc1.fastq", "1858", "5", "1"));
-                    put(1, Arrays.asList("lbc2--lbc2.fastq", "1859", "12", "1"));
-                }});
+                put(0, Arrays.asList("lbc1--lbc1.fastq", "1858", "5", "1"));
+                put(1, Arrays.asList("lbc2--lbc2.fastq", "1859", "12", "1"));
+            }});
     private static final Map<Integer, List<String>> POOL2_DATA =
-            Collections.unmodifiableMap(new HashMap<Integer, List<String>>()
+            Collections.unmodifiableMap(new HashMap<>()
             {{
-                    put(0, Arrays.asList("lbc14--lbc14.fastq.gz", "1871", "7", "2"));
-                    put(1, Arrays.asList("lbc15--lbc15.fastq.gz", "1872", "6", "2"));
-                    put(2, Arrays.asList("lbc16--lbc16.fastq.gz", "1873", "0", "2"));
-                }});
+                put(0, Arrays.asList("lbc14--lbc14.fastq.gz", "1871", "7", "2"));
+                put(1, Arrays.asList("lbc15--lbc15.fastq.gz", "1872", "6", "2"));
+                put(2, Arrays.asList("lbc16--lbc16.fastq.gz", "1873", "0", "2"));
+            }});
 
     @BeforeClass
     public static void setupProject()
     {
-        PacBioTest init = (PacBioTest)getCurrentTest();
+        PacBioTest init = getCurrentTest();
         init.doSetup();
     }
 


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


