### PR TITLE
Issue 53306: Some LKS forms don't distinguish between fields properly

### DIFF
--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -25,10 +25,10 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.CustomModules;
 import org.labkey.test.categories.OConnor;
 import org.labkey.test.components.DomainDesignerPage;
+import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
-import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.ListHelper;
@@ -588,7 +588,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
     {
         log("Importing Haplotype Run: " + assayId);
         goToAssayImport(assayName);
-        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, assayId);
+        setFormElement(AssayConstants.ASSAY_NAME_FIELD_LOCATOR, assayId);
         checkCheckbox(Locator.name("enabled"));
         selectOptionByText(Locator.name("speciesId"), "mamu");
         // NOTE: consider breaking these into seperate tests...

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -28,6 +28,7 @@ import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.tests.study.AssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.ListHelper;
@@ -587,7 +588,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
     {
         log("Importing Haplotype Run: " + assayId);
         goToAssayImport(assayName);
-        setFormElement(Locator.name("name"), assayId);
+        setFormElement(AssayTest.ASSAY_NAME_FIELD_LOCATOR, assayId);
         checkCheckbox(Locator.name("enabled"));
         selectOptionByText(Locator.name("speciesId"), "mamu");
         // NOTE: consider breaking these into seperate tests...


### PR DESCRIPTION
#### Rationale
Some `<input>` fields are using `name` attributes that don't differentiate from similarly named fields.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6804

#### Changes
- Update to use new naming convention
