### PR TITLE
Fix data region column name references

### DIFF
--- a/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
+++ b/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
@@ -146,7 +146,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
         assertEquals(description, table.getDataAsText(row, "Description"));
         if (type != null)
         {
-            assertEquals(type, table.getDataAsText(row, "ExperimentType"));
+            assertEquals(type, table.getDataAsText(row, "ExperimentTypeId"));
         }
 
         // Make sure each component of the ParentExperiments column is rendered with a link to the begin page for that experiment

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -325,7 +325,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
 
         // validate extra column in view
         DataRegionTable drt = new DataRegionTable("Data", this);
-        verifyColumnDataValues(drt, "ClientAnimalId", "x456", "x567", "x678", "x789", "x888", "x999");
+        verifyColumnDataValues(drt, "AnimalId/ClientAnimalId", "x456", "x567", "x678", "x789", "x888", "x999");
 
         // verify that the animal and haplotype rows were properly inserted
         goToQuery("Animal");
@@ -345,10 +345,10 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         verifyColumnDataValues(drt, "TotalReads", "4000", "5000", "6000", "7000", " ", "0");
         verifyColumnDataValues(drt, "IdentifiedReads", "2500", "3250", "3000", "3500", " ", "1");
         verifyColumnDataValues(drt, "PercentUnknown", "37.5", "35.0", "50.0", "50.0", " ", " ");
-        verifyColumnDataValues(drt, prefix+"-AHaplotype1", "A001", " ", "A033", "A004", "A004", "A004");
-        verifyColumnDataValues(drt, prefix+"-AHaplotype2", "A023", " ", "A033", " ", "A004", "A004");
-        verifyColumnDataValues(drt, prefix+"-BHaplotype1", "B015c", " ", "B012b", "B033", "B033", "B033");
-        verifyColumnDataValues(drt, prefix+"-BHaplotype2", "B025a", " ", "B012b", "B033", "B033", "B033");
+        verifyColumnDataValues(drt, prefix+"AHaplotype1", "A001", " ", "A033", "A004", "A004", "A004");
+        verifyColumnDataValues(drt, prefix+"AHaplotype2", "A023", " ", "A033", " ", "A004", "A004");
+        verifyColumnDataValues(drt, prefix+"BHaplotype1", "B015c", " ", "B012b", "B033", "B033", "B033");
+        verifyColumnDataValues(drt, prefix+"BHaplotype2", "B025a", " ", "B012b", "B033", "B033", "B033");
         verifyColumnDataValues(drt, "Enabled", "true", "true", "true", "true", "true", "true");
 
         // verify concatenated haplotype strings

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -160,10 +160,10 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         clickAndWait(Locator.linkWithText(DRB_RUN));
         DataRegionTable drt = new DataRegionTable("Data", this);
 
-        verifyColumnDataValues(drt, "MHC-AHaplotype1", "A001", "A023", "A001", "A004", "A002a");
-        verifyColumnDataValues(drt, "MHC-AHaplotype2", "A023", "A021", "A001", "A023", "A002a");
-        verifyColumnDataValues(drt, "MHC-DRB Haplotype 1", "D025a", "D012b", "D001c", "D012b", "D002");
-        verifyColumnDataValues(drt, "MHC-DRB Haplotype 2", "D015c", "D017a", "D017a", "D012b", "D002");
+        verifyColumnDataValues(drt, "mhcAHaplotype1", "A001", "A023", "A001", "A004", "A002a");
+        verifyColumnDataValues(drt, "mhcAHaplotype2", "A023", "A021", "A001", "A023", "A002a");
+        verifyColumnDataValues(drt, "mhcDRBHaplotype1", "D025a", "D012b", "D001c", "D012b", "D002");
+        verifyColumnDataValues(drt, "mhcDRBHaplotype2", "D015c", "D017a", "D017a", "D012b", "D002");
 
         importRun(STR_RUN, DRB_ASSAY, STR_RUN_FILE, true);
 
@@ -398,14 +398,14 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         waitForElement(Locator.paginationText(1, 39, 39));
 
         // ADD: animal ID-5, haplotype A001
-        DataRegionTable.findDataRegion(this).clickInsertNewRow();
+        DataRegionTable.DataRegion(getDriver()).find().clickInsertNewRow();
         selectOptionByText(Locator.name("quf_HaplotypeId"), "A001");
         selectOptionByText(Locator.name("quf_AnimalAnalysisId"), animalAnalysisId);
         setFormElement(Locator.name("quf_DiploidNumber"), "1");
         clickButton("Submit");
 
         // ADD: animal ID-5, haplotype B002
-        DataRegionTable.findDataRegion(this).clickInsertNewRow();
+        DataRegionTable.DataRegion(getDriver()).find().clickInsertNewRow();
         selectOptionByText(Locator.name("quf_HaplotypeId"), "B002");
         selectOptionByText(Locator.name("quf_AnimalAnalysisId"), animalAnalysisId);
         setFormElement(Locator.name("quf_DiploidNumber"), "1");
@@ -416,10 +416,10 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         goToAssayRun("first run");
         drt = new DataRegionTable("Data", this);
         drt.setFilter("AnimalId", "Equals", "ID-5");
-        verifyColumnDataValues(drt, "MHC-AHaplotype1", "A001");
-        verifyColumnDataValues(drt, "MHC-AHaplotype2", "A002a");
-        verifyColumnDataValues(drt, "MHC-BHaplotype1", "B002");
-        verifyColumnDataValues(drt, "MHC-BHaplotype2", "B002");
+        verifyColumnDataValues(drt, "mhcAHaplotype1", "A001");
+        verifyColumnDataValues(drt, "mhcAHaplotype2", "A002a");
+        verifyColumnDataValues(drt, "mhcBHaplotype1", "B002");
+        verifyColumnDataValues(drt, "mhcBHaplotype2", "B002");
         drt.clearFilter("AnimalId");
 
         // NOTE: this should clean up what it has done in order to make the test more modular...

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -287,12 +287,12 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         verifyColumnDataValues(drt, "TotalReads", "1000", "2000", "3000", "4000", "5000");
         verifyColumnDataValues(drt, "IdentifiedReads", "300", "1000", "600", "2500", "3250");
         verifyColumnDataValues(drt, "PercentUnknown", "70.0", "50.0", "80.0", "37.5", "35.0");
-        verifyColumnDataValues(drt, "MHC-AHaplotype1", "A001", "A023", "A001", "A004", "A002a");
-        verifyColumnDataValues(drt, "MHC-AHaplotype2", "A023", "A021", "A001", "A023", "A002a");
-        verifyColumnDataValues(drt, "MHC-BHaplotype1", "B015c", "B012b", "B001c", "B012b", "B002");
-        verifyColumnDataValues(drt, "MHC-BHaplotype2", "B025a", "B017a", "B017a", "B012b", "B002");
+        verifyColumnDataValues(drt, "mhcAHaplotype1", "A001", "A023", "A001", "A004", "A002a");
+        verifyColumnDataValues(drt, "mhcAHaplotype2", "A023", "A021", "A001", "A023", "A002a");
+        verifyColumnDataValues(drt, "mhcBHaplotype1", "B015c", "B012b", "B001c", "B012b", "B002");
+        verifyColumnDataValues(drt, "mhcBHaplotype2", "B025a", "B017a", "B017a", "B012b", "B002");
         verifyColumnDataValues(drt, "Enabled", "true", "true", "true", "true", "true");
-        verifyColumnDataValues(drt, "ClientAnimalId", "x123", "x234", "x345", "x456", "x567");
+        verifyColumnDataValues(drt, "AnimalId/ClientAnimalId", "x123", "x234", "x345", "x456", "x567");
 
         // verify concatenated haplotype strings
         List<String> concatenated = drt.getColumnDataAsText("ConcatenatedHaplotypes");
@@ -307,8 +307,8 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         goToQuery("Animal");
         drt = new DataRegionTable("query", this);
         assertEquals("Unexpected number of Animal records", 5, drt.getDataRowCount());
-        verifyColumnDataValues(drt, "Lab Animal Id", "ID-1", "ID-2", "ID-3", "ID-4", "ID-5");
-        verifyColumnDataValues(drt, "Client Animal Id", "x123", "x234", "x345", "x456", "x567");
+        verifyColumnDataValues(drt, "LabAnimalId", "ID-1", "ID-2", "ID-3", "ID-4", "ID-5");
+        verifyColumnDataValues(drt, "ClientAnimalId", "x123", "x234", "x345", "x456", "x567");
 
         verifyHaplotypeRecordsByType(11, 5, 6);
     }

--- a/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/HaplotypeAssayTest.java
@@ -286,7 +286,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         verifyColumnDataValues(drt, "Animal", "ID-1", "ID-2", "ID-3", "ID-4", "ID-5");
         verifyColumnDataValues(drt, "TotalReads", "1000", "2000", "3000", "4000", "5000");
         verifyColumnDataValues(drt, "IdentifiedReads", "300", "1000", "600", "2500", "3250");
-        verifyColumnDataValues(drt, "%Unknown", "70.0", "50.0", "80.0", "37.5", "35.0");
+        verifyColumnDataValues(drt, "PercentUnknown", "70.0", "50.0", "80.0", "37.5", "35.0");
         verifyColumnDataValues(drt, "MHC-AHaplotype1", "A001", "A023", "A001", "A004", "A002a");
         verifyColumnDataValues(drt, "MHC-AHaplotype2", "A023", "A021", "A001", "A023", "A002a");
         verifyColumnDataValues(drt, "MHC-BHaplotype1", "B015c", "B012b", "B001c", "B012b", "B002");
@@ -344,7 +344,7 @@ public class HaplotypeAssayTest extends GenotypingBaseTest
         verifyColumnDataValues(drt, "Animal", "ID-4", "ID-5", "ID-6", "ID-7", "ID-8", "ID-9");
         verifyColumnDataValues(drt, "TotalReads", "4000", "5000", "6000", "7000", " ", "0");
         verifyColumnDataValues(drt, "IdentifiedReads", "2500", "3250", "3000", "3500", " ", "1");
-        verifyColumnDataValues(drt, "%Unknown", "37.5", "35.0", "50.0", "50.0", " ", " ");
+        verifyColumnDataValues(drt, "PercentUnknown", "37.5", "35.0", "50.0", "50.0", " ", " ");
         verifyColumnDataValues(drt, prefix+"-AHaplotype1", "A001", " ", "A033", "A004", "A004", "A004");
         verifyColumnDataValues(drt, prefix+"-AHaplotype2", "A023", " ", "A033", " ", "A004", "A004");
         verifyColumnDataValues(drt, prefix+"-BHaplotype1", "B015c", " ", "B012b", "B033", "B033", "B033");


### PR DESCRIPTION
#### Rationale
My previous DataRegionTable refactor attempted to recreate the previous behavior that would remove spaces when matching field labels. I covered the case where the test passed in an unnecessary space but not when they omitted a space. Rather that duplicating that particular behavior, this updates the handful of tests that are passing incorrect field labels.

I've also updated the `CustomizeView` helper to accept `FieldKey` objects instead of String arrays.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2526

#### Changes
- Remove unnecessary logging parameters from the CustomizeView helper
- Update CustomizeViewHelper to use FieldKey
- Fix problematic data region column name references