### PR TITLE
Rename SaveRowsResponse to RowsResponse

### DIFF
--- a/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
+++ b/OConnorExperiments/test/src/org/labkey/test/tests/OConnorExperimentTest.java
@@ -23,7 +23,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
@@ -274,7 +274,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
             Connection cn = WebTestHelper.getRemoteApiConnection();
             InsertRowsCommand insertCmd = new InsertRowsCommand(SCHEMA_NAME, TABLE_NAME);
             insertCmd.addRow(rowMap);
-            SaveRowsResponse resp = insertCmd.execute(cn, getProjectName());
+            RowsResponse resp = insertCmd.execute(cn, getProjectName());
             for (int i = 0; i < insertCmd.getRows().size(); i++)
             {
                 Map<String, Object> row = resp.getRows().get(i);
@@ -301,7 +301,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
             rowMap.put("Description", "API Description Edited");
             rowMap.put("ExperimentType", "API Type Edited");
             Connection cn = WebTestHelper.getRemoteApiConnection();
-            SaveRowsResponse resp = cmd.execute(cn, getProjectName());
+            RowsResponse resp = cmd.execute(cn, getProjectName());
             assertEquals("Expected to update " + rowMap.size() + " rows", rowMap.size(), resp.getRowsAffected().intValue());
             goToProjectHome();
         }
@@ -329,7 +329,7 @@ public class OConnorExperimentTest extends BaseWebDriverTest implements Postgres
             for (String pk : pkeys)
                 cmd.addRow(Collections.singletonMap("container", pk));
 
-            SaveRowsResponse resp = cmd.execute(cn, getProjectName());
+            RowsResponse resp = cmd.execute(cn, getProjectName());
             assertEquals("Expected to delete " + pkeys.size() + " rows", pkeys.size(), resp.getRowsAffected().intValue());
 
             SelectRowsCommand selectCmd = new SelectRowsCommand(SCHEMA_NAME, TABLE_NAME);

--- a/genotyping/test/src/org/labkey/test/tests/GenotypingBaseTest.java
+++ b/genotyping/test/src/org/labkey/test/tests/GenotypingBaseTest.java
@@ -20,7 +20,7 @@ import org.junit.BeforeClass;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -135,7 +135,7 @@ abstract public class GenotypingBaseTest extends BaseWebDriverTest implements Po
         Connection cn = WebTestHelper.getRemoteApiConnection();
         DeleteRowsCommand cmd = new DeleteRowsCommand("genotyping", "IlluminaTemplates");
         cmd.addRow(Collections.singletonMap("Name", TEMPLATE_NAME));
-        SaveRowsResponse resp;
+        RowsResponse resp;
         try
         {
             resp = cmd.execute(cn, getProjectName());


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83

#### Changes
- Rename `SaveRowsResponse` to `RowsResponse`
