### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/OConnorExperiments/src/org/labkey/oconnorexperiments/view/history.jsp
+++ b/OConnorExperiments/src/org/labkey/oconnorexperiments/view/history.jsp
@@ -24,10 +24,8 @@
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.query.UserSchema" %>
 <%@ page import="org.labkey.api.security.User" %>
-<%@ page import="org.labkey.api.services.ServiceRegistry" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.api.view.WebPartView" %>
-<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.api.wiki.WikiService" %>
 <%@ page import="org.labkey.oconnorexperiments.query.OConnorExperimentsUserSchema" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -86,7 +84,7 @@
 <h3>Notes History</h3>
 <%
     {
-        WebPartView view = WikiService.get().getHistoryView(c, "default");
+        WebPartView<?> view = WikiService.get().getHistoryView(c, "default");
         if (view != null)
             include(view, out);
     }

--- a/genotyping/src/org/labkey/genotyping/GenotypingAnalysesView.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingAnalysesView.java
@@ -41,9 +41,9 @@ public class GenotypingAnalysesView extends QueryView
     public static final WebPartFactory FACTORY = new BaseWebPartFactory("Genotyping Analyses")
     {
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext ctx, @NotNull Portal.WebPart webPart)
+        public WebPartView<?> getWebPartView(@NotNull ViewContext ctx, @NotNull Portal.WebPart webPart)
         {
-            WebPartView view = new GenotypingAnalysesView(ctx, null, "GenotypingAnalyses");
+            WebPartView<?> view = new GenotypingAnalysesView(ctx, null, "GenotypingAnalyses");
             view.setTitle("Genotyping Analyses");
             view.setTitleHref(GenotypingController.getAnalysesURL(ctx.getContainer()));
             return view;

--- a/genotyping/src/org/labkey/genotyping/GenotypingModule.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingModule.java
@@ -140,16 +140,14 @@ public class GenotypingModule extends DefaultModule
         return Collections.singleton(GenotypingSchema.get().getSchemaName());
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return PageFlowUtil.set(HaplotypeDataHandler.TestCase.class, IlluminaFastqParser.DupeTestCase.class);
     }
 
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(IlluminaFastqParser.HeaderTestCase.class, ImportAnalysisJob.TestCase.class);
     }

--- a/genotyping/src/org/labkey/genotyping/GenotypingRunsView.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingRunsView.java
@@ -42,9 +42,9 @@ public class GenotypingRunsView extends QueryView
     public static final WebPartFactory FACTORY = new BaseWebPartFactory("Sequencing Runs")
     {
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext ctx, @NotNull Portal.WebPart webPart)
+        public WebPartView<?> getWebPartView(@NotNull ViewContext ctx, @NotNull Portal.WebPart webPart)
         {
-            WebPartView view = new GenotypingRunsView(ctx, null, "SequencingRuns", false);
+            WebPartView<?> view = new GenotypingRunsView(ctx, null, "SequencingRuns", false);
             view.setTitle("Sequencing Runs");
             view.setTitleHref(GenotypingController.getRunsURL(ctx.getContainer()));
             return view;

--- a/genotyping/src/org/labkey/genotyping/GenotypingWebPart.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingWebPart.java
@@ -36,7 +36,7 @@ public class GenotypingWebPart extends JspView
     public static final WebPartFactory FACTORY = new BaseWebPartFactory("Genotyping Overview")
     {
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+        public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             return new GenotypingWebPart();
         }


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.