### PR TITLE
Replace AbstractContainerListener with ContainerListener default

### DIFF
--- a/genotyping/src/org/labkey/genotyping/GenotypingContainerListener.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingContainerListener.java
@@ -20,7 +20,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-public class GenotypingContainerListener extends ContainerManager.AbstractContainerListener
+public class GenotypingContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)


### PR DESCRIPTION
#### Rationale
Reduce boilerplate and empty methods. Most implementations only override one or two methods.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7154

#### Changes
- Remove `AbstractContainerListener`. Replace with default implementation of methods on `ContainerListener` interface.