### PR TITLE
Add an upgrade script to assign correct types to createdBy, modifiedBy, and container columns

### DIFF
--- a/OConnor/module.properties
+++ b/OConnor/module.properties
@@ -1,4 +1,4 @@
 Name: OConnor
-SchemaVersion: 25.001
+SchemaVersion: 26.001
 RequiredServerVersion: 16.30
 ManageVersion: true

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-0.000-23.000.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-0.000-23.000.sql
@@ -195,22 +195,6 @@ CREATE TABLE oconnor.grants (
 
 
 --
--- Name: active_grants; Type: VIEW; Schema: oconnor; Owner: oconnor
---
-
-CREATE VIEW oconnor.active_grants AS
-    SELECT g.id, g.container, (((g.id)::text || ' - '::text) || g.title) AS displaytitle FROM oconnor.grants g WHERE ((g.enabled = true) AND (now() < g.expiration_date));
-
-
---
--- Name: active_quotes; Type: VIEW; Schema: oconnor; Owner: oconnor
---
-
-CREATE VIEW oconnor.active_quotes AS
-    SELECT g.id, g.container, (((g.id)::text || ' - '::text) || g.title) AS displaytitle FROM oconnor.grants g WHERE ((g.enabled = true) AND (now() < g.expiration_date));
-
-
---
 -- Name: oc_sequence; Type: SEQUENCE; Schema: oconnor; Owner: oconnor
 --
 
@@ -805,14 +789,6 @@ CREATE TABLE oconnor.virus_challenges (
     remark character varying(255) NOT NULL,
     challenge_type character varying(255) NOT NULL
 );
-
-
---
--- Name: max_virus_challenge_date; Type: VIEW; Schema: oconnor; Owner: oconnor
---
-
-CREATE VIEW oconnor.max_virus_challenge_date AS
-    SELECT v.id, max(v.challenge_date) AS challenge_date FROM oconnor.virus_challenges v WHERE ((v.challenge_type)::text ~~ '%SIV%'::text) GROUP BY v.id;
 
 
 --

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
@@ -1,0 +1,19 @@
+DO $$
+  DECLARE
+rec RECORD;
+BEGIN
+FOR rec IN
+SELECT table_name, column_name
+FROM information_schema.columns
+WHERE table_schema = 'oconnor'
+  AND lower(column_name) IN ('createdby',
+                             'modifiedby')
+  AND data_type = 'smallint'
+    LOOP
+          EXECUTE format(
+              'ALTER TABLE oconnor.%I ALTER COLUMN %I
+  TYPE userid',
+              rec.table_name, rec.column_name
+          );
+END LOOP;
+END $$;

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
@@ -5,7 +5,7 @@ BEGIN
 FOR rec IN
 SELECT c.table_name, c.column_name
 FROM information_schema.columns c
-         JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
 WHERE c.table_schema = 'oconnor'
   AND t.table_type = 'BASE TABLE'
   AND lower(c.column_name) IN ('createdby',
@@ -23,43 +23,20 @@ END $$;
 DO $$
   DECLARE
 rec RECORD;
-    view_rec RECORD;
 BEGIN
-    -- Save view definitions and drop all views in oconnor schema to clear dependencies
-    CREATE TEMP TABLE _oconnor_view_defs (viewname text, definition text);
-
-FOR view_rec IN
-SELECT viewname, definition
-FROM pg_views
-WHERE schemaname = 'oconnor'
-    LOOP
-INSERT INTO _oconnor_view_defs VALUES (view_rec.viewname, view_rec.definition);
-EXECUTE format('DROP VIEW IF EXISTS oconnor.%I CASCADE', view_rec.viewname);
-END LOOP;
-
-    -- Alter container columns on base tables
 FOR rec IN
 SELECT c.table_name, c.column_name
 FROM information_schema.columns c
-         JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
 WHERE c.table_schema = 'oconnor'
   AND t.table_type = 'BASE TABLE'
   AND lower(c.column_name) = 'container'
   AND c.data_type = 'character varying'
     LOOP
-        EXECUTE format(
-            'ALTER TABLE oconnor.%I ALTER COLUMN %I
+          EXECUTE format(
+              'ALTER TABLE oconnor.%I ALTER COLUMN %I
   TYPE entityid',
-            rec.table_name, rec.column_name
-        );
+              rec.table_name, rec.column_name
+          );
 END LOOP;
-
-    -- Recreate views from saved definitions
-FOR view_rec IN
-SELECT viewname, definition FROM _oconnor_view_defs
-    LOOP
-    EXECUTE format('CREATE OR REPLACE VIEW oconnor.%I AS %s', view_rec.viewname, view_rec.definition);
-END LOOP;
-
-DROP TABLE _oconnor_view_defs;
 END $$;

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.000-26.001.sql
@@ -3,12 +3,14 @@ DO $$
 rec RECORD;
 BEGIN
 FOR rec IN
-SELECT table_name, column_name
-FROM information_schema.columns
-WHERE table_schema = 'oconnor'
-  AND lower(column_name) IN ('createdby',
-                             'modifiedby')
-  AND data_type = 'smallint'
+SELECT c.table_name, c.column_name
+FROM information_schema.columns c
+         JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+WHERE c.table_schema = 'oconnor'
+  AND t.table_type = 'BASE TABLE'
+  AND lower(c.column_name) IN ('createdby',
+                               'modifiedby')
+  AND c.data_type = 'smallint'
     LOOP
           EXECUTE format(
               'ALTER TABLE oconnor.%I ALTER COLUMN %I
@@ -16,4 +18,48 @@ WHERE table_schema = 'oconnor'
               rec.table_name, rec.column_name
           );
 END LOOP;
+END $$;
+
+DO $$
+  DECLARE
+rec RECORD;
+    view_rec RECORD;
+BEGIN
+    -- Save view definitions and drop all views in oconnor schema to clear dependencies
+    CREATE TEMP TABLE _oconnor_view_defs (viewname text, definition text);
+
+FOR view_rec IN
+SELECT viewname, definition
+FROM pg_views
+WHERE schemaname = 'oconnor'
+    LOOP
+INSERT INTO _oconnor_view_defs VALUES (view_rec.viewname, view_rec.definition);
+EXECUTE format('DROP VIEW IF EXISTS oconnor.%I CASCADE', view_rec.viewname);
+END LOOP;
+
+    -- Alter container columns on base tables
+FOR rec IN
+SELECT c.table_name, c.column_name
+FROM information_schema.columns c
+         JOIN information_schema.tables t ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+WHERE c.table_schema = 'oconnor'
+  AND t.table_type = 'BASE TABLE'
+  AND lower(c.column_name) = 'container'
+  AND c.data_type = 'character varying'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE oconnor.%I ALTER COLUMN %I
+  TYPE entityid',
+            rec.table_name, rec.column_name
+        );
+END LOOP;
+
+    -- Recreate views from saved definitions
+FOR view_rec IN
+SELECT viewname, definition FROM _oconnor_view_defs
+    LOOP
+    EXECUTE format('CREATE OR REPLACE VIEW oconnor.%I AS %s', view_rec.viewname, view_rec.definition);
+END LOOP;
+
+DROP TABLE _oconnor_view_defs;
 END $$;

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-create.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-create.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+CREATE VIEW oconnor.active_grants AS
+    SELECT g.id, g.container, (g.id::text || ' - ' || g.title) AS displaytitle
+    FROM oconnor.grants g
+    WHERE g.enabled = true AND now() < g.expiration_date;
+
+CREATE VIEW oconnor.active_quotes AS
+    SELECT g.id, g.container, (g.id::text || ' - ' || g.title) AS displaytitle
+    FROM oconnor.grants g
+    WHERE g.enabled = true AND now() < g.expiration_date;
+
+CREATE VIEW oconnor.max_virus_challenge_date AS
+    SELECT v.id, max(v.challenge_date) AS challenge_date
+    FROM oconnor.virus_challenges v
+    WHERE v.challenge_type::text LIKE '%SIV%'
+    GROUP BY v.id;

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-drop.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-drop.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+-- DROP all views (current and obsolete)
+
+-- NOTE: Don't remove any of these drop statements, even if we stop re-creating the view in *-create.sql. Drop statements must
+-- remain in place so we can correctly upgrade from older versions, which we commit to for two years after each release.
+
+SELECT core.fn_dropifexists('max_virus_challenge_date', 'oconnor', 'VIEW', NULL);
+SELECT core.fn_dropifexists('active_quotes', 'oconnor', 'VIEW', NULL);
+SELECT core.fn_dropifexists('active_grants', 'oconnor', 'VIEW', NULL);


### PR DESCRIPTION
#### Rationale
Most tables were originally created directly in the database for an on-premise  deployment. Module-based schema upgrade scripts were later added to maintain them going forward, but the createdBy and modifiedBy columns were inadvertently defined as smallint (int2) instead of the userid type (int4). This type mismatch causes it to skip auto-populating these columns during inserts, resulting in a NOT NULL constraint violation.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Added an upgrade script that updates all 'createdBy' and 'modifiedBy' columns from 'smallint' type to 'userid' type.
* Assign 'entityid' type to the 'container' column.
* Split views from an upgrade script to oconnor-create.sql.
* Add oconnor-drop.sql to drop the views.

- [x] Manual testing @labkey-jeckels 