### PR TITLE
Drop redundant indices

### DIFF
--- a/OConnor/module.properties
+++ b/OConnor/module.properties
@@ -1,4 +1,4 @@
 Name: OConnor
-SchemaVersion: 26.001
+SchemaVersion: 26.002
 RequiredServerVersion: 16.30
 ManageVersion: true

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
@@ -1,0 +1,7 @@
+-- Dropping key [key] because it overlaps with inventorytemp_pkey [key]
+DROP INDEX oconnor.key;
+-- Dropping experiment_db_experiment_number_key [experiment_number] because it overlaps with pk_experiment_db [experiment_number]
+DROP INDEX oconnor.experiment_db_experiment_number_key;
+-- Converting experiment_db_experiment_number_created_createdby_description_t [experiment_number, created, createdby, description, type, parents, workbook, container, modifiedby, modified, comments] from unique to non-unique index because pk_experiment_db [experiment_number] overlaps it with a smaller column set
+DROP INDEX oconnor.experiment_db_experiment_number_created_createdby_description_t;
+CREATE INDEX experiment_db_experiment_number_created_createdby_description_t ON oconnor.experiment_db(experiment_number, created, createdby, description, type, parents, workbook, container, modifiedby, modified, comments);

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
@@ -3,5 +3,5 @@ DROP INDEX oconnor.key;
 -- Dropping experiment_db_experiment_number_key [experiment_number] because it overlaps with pk_experiment_db [experiment_number]
 DROP INDEX oconnor.experiment_db_experiment_number_key;
 -- Dropping unique index because pk_experiment_db [experiment_number] overlaps it with a smaller column set. Not bothering
--- to convert this unique index to a non-unique index because it has 11 columns, which is an absurd.
+-- to convert this unique index to a non-unique index because it has 11 columns, which is absurd.
 DROP INDEX oconnor.experiment_db_experiment_number_created_createdby_description_t;

--- a/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
+++ b/OConnor/resources/schemas/dbscripts/postgresql/oconnor-26.001-26.002.sql
@@ -2,6 +2,6 @@
 DROP INDEX oconnor.key;
 -- Dropping experiment_db_experiment_number_key [experiment_number] because it overlaps with pk_experiment_db [experiment_number]
 DROP INDEX oconnor.experiment_db_experiment_number_key;
--- Converting experiment_db_experiment_number_created_createdby_description_t [experiment_number, created, createdby, description, type, parents, workbook, container, modifiedby, modified, comments] from unique to non-unique index because pk_experiment_db [experiment_number] overlaps it with a smaller column set
+-- Dropping unique index because pk_experiment_db [experiment_number] overlaps it with a smaller column set. Not bothering
+-- to convert this unique index to a non-unique index because it has 11 columns, which is an absurd.
 DROP INDEX oconnor.experiment_db_experiment_number_created_createdby_description_t;
-CREATE INDEX experiment_db_experiment_number_created_createdby_description_t ON oconnor.experiment_db(experiment_number, created, createdby, description, type, parents, workbook, container, modifiedby, modified, comments);

--- a/genotyping/resources/schemas/dbscripts/postgresql/genotyping-26.000-26.001.sql
+++ b/genotyping/resources/schemas/dbscripts/postgresql/genotyping-26.000-26.001.sql
@@ -1,0 +1,7 @@
+-- Dropping idx_animalanalysis_animal [AnimalId] because it overlaps with uq_animalanalysis [AnimalId, RunId]
+DROP INDEX genotyping.idx_animalanalysis_animal;
+-- Dropping idx_animal_container [Container] because it overlaps with uq_animal_labanimalid [Container, LabAnimalId]
+DROP INDEX genotyping.idx_animal_container;
+-- Converting unique_runs [RowId, Container, MetaDataId] from unique to non-unique index because pk_runs [RowId] overlaps it with a smaller column set
+ALTER TABLE genotyping.Runs DROP CONSTRAINT unique_runs;
+CREATE INDEX index_runs ON genotyping.Runs(RowId, Container, MetaDataId);

--- a/genotyping/src/org/labkey/genotyping/GenotypingModule.java
+++ b/genotyping/src/org/labkey/genotyping/GenotypingModule.java
@@ -51,7 +51,7 @@ public class GenotypingModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630